### PR TITLE
Added secure double JWT option

### DIFF
--- a/classes/Application.php
+++ b/classes/Application.php
@@ -2,675 +2,685 @@
 namespace ProcessWire;
 
 class Application extends WireData {
-	private $initiated = false;
-	protected $id;
-	protected $title;
-	protected $description;
-	protected $created;
-	protected $createdUser;
-	protected $modified;
-	protected $modifiedUser;
-
-	protected $tokenSecret;
-	protected $accesstokenSecret;
-
-	protected $defaultApplication;
-	protected $expiresIn;
-
-	protected $authtype = 0;
-
-	/*
-	 * A normal website-application can be used to access public data with only a valid apikey. Protected data will be authorized with classic php-sessions. If you are logged in, you can use protected apipages.
-	 */
-	const authtypeSession = 0;
-
-	/**
-	 * A protected website-application shows contents only if you have a valid JWT-token that authorizes you to use an endpoint. A JWT-token should be requested via PHP and has to be transferred to JS on pageload (e.g. as a special data-attribute). It can be limited to only those special endpoints that the api function uses. The JWT-token is linked to the php-session so it has a limited livetime. With protectedWebsite-endpoints we can prevent that api-access via token can be used for general apicalls from other services.
-	 */
-	const authtypeSingleJWT = 1;
-
-	/*
-	 * A classic app allows users to log in and authenticate via refresh- and access-tokens afterwards. Public contents are available with only a valid apikey.
-	 */
-	const authtypeDoubleJWT = 2;
-
-	public static function getAuthtypeLabel($authtype) {
-		if ($authtype === self::authtypeSession) {
-			return __('PHP Session');
-		} elseif ($authtype === self::authtypeSingleJWT) {
-			return __('Single JWT');
-		} elseif ($authtype === self::authtypeDoubleJWT) {
-			return __('Double JWT');
-		}
-		return 'Unknown: ' . $authtype;
-	}
-
-	const logintypeOptions = [
-		'logintypeUsernamePassword',
-		'logintypeEmailPassword'
-	];
-
-	protected $logintype = ['logintypeUsernamePassword'];
-
-
-	public static function getLogintypeLabel($logintype) {
-		if ($logintype === self::logintypeOptions[0]) {
-			return __('Username sign-in');
-		} elseif ($logintype === self::logintypeOptions[1]) {
-			return __('Email sign-in');
-		}
-		return 'Unknown: ' . $loginype;
-	}
-
-
-	public function __construct(array $import = []) {
-		$this->id = null;
-		$this->created = time();
-		$this->createdUser = null;
-		$this->modified = time();
-		$this->modifiedUser = null;
-		$this->title = '';
-		$this->description = '';
-		$this->defaultApplication = false;
-
-		$this->tokenSecret = '';
-		$this->accesstokenSecret = '';
-
-		$this->expiresIn = 30 * 24 * 60 * 60; // default: 30 days
-
-		if (is_array($import) && wireCount($import) > 0) {
-			$this->import($import);
-		}
-		if ($this->isNew()) {
-			$this->created = time();
-			$this->createdUser = $this->wire('user');
-			$this->modified = time();
-			$this->modifiedUser = $this->wire('user');
-		}
-		$this->initiated = true;
-	}
-
-	protected function import(array $values) {
-		if (!isset($values['id'])) {
-			throw new ApplicationException('You cannot import an application without an id.');
-		}
-		$this->id = (int)$values['id'];
-
-		if (isset($values['created'])) {
-			$this->___setCreated($values['created']);
-		}
-		if (isset($values['created_user_id'])) {
-			$this->___setCreatedUser($values['created_user_id']);
-		}
-
-		if (isset($values['modified'])) {
-			$this->___setModified($values['modified']);
-		}
-		if (isset($values['modified_user_id'])) {
-			$this->___setModifiedUser($values['modified_user_id']);
-		}
-
-		if (isset($values['title'])) {
-			$this->___setTitle($values['title']);
-		}
-
-		if (isset($values['description'])) {
-			$this->___setDescription($values['description']);
-		}
-
-		if (isset($values['default_application'])) {
-			$this->___setDefaultApplication($values['default_application']);
-		}
-
-		if (isset($values['token_secret'])) {
-			$this->___setTokenSecret($values['token_secret']);
-		}
-
-		if (isset($values['accesstoken_secret'])) {
-			$this->___setAccesstokenSecret($values['accesstoken_secret']);
-		}
-
-		if (isset($values['authtype'])) {
-			$this->___setAuthtype($values['authtype']);
-		}
-
-		if (isset($values['logintype']) && !!json_decode($values['logintype'])) {
-			$this->___setLogintype(json_decode($values['logintype']));
-		}
-
-		if (isset($values['expires_in'])) {
-			$this->___setExpiresIn($values['expires_in']);
-		}
-	}
-
-	public function ___isSaveable() {
-		if (!$this->isValid()) {
-			return false;
-		}
-		return true;
-	}
-
-	public function ___isValid() {
-		return $this->isIDValid() && $this->isCreatedValid() && $this->isCreatedUserValid() && $this->isModifiedValid() && $this->isModifiedUserValid() && $this->isTitleValid() && $this->isDescriptionValid() && $this->isTokenSecretValid() && $this->isAccesstokenSecretValid() && $this->isAuthtypeValid() && $this->isLogintypeValid() && $this->isExpiresInValid() && $this->isDefaultApplicationValid();
-	}
-
-	public function ___isNew() {
-		return empty($this->id);
-	}
-
-	public function getID() {
-		return $this->id;
-	}
-
-	public function isIDValid($value = false) {
-		if ($value === false) {
-			$value = $this->id;
-		}
-		return $value === null || (is_integer($value) && $value >= 0);
-	}
-
-	public function ___setCreated($created) {
-		if (is_string($created)) {
-			$created = strtotime($created);
-		}
-
-		if (!$this->isCreatedValid($created)) {
-			throw new ApplicationException('No valid modified date');
-		}
-
-		$this->created = $created;
-		return $this->created;
-	}
-
-	public function isCreatedValid($value = false) {
-		if ($value === false) {
-			$value = $this->created;
-		}
-		return is_integer($value) && $value > 0;
-	}
-
-	public function getCreated() {
-		return $this->created;
-	}
-
-	public function ___setCreatedUser($createdUser) {
-		if (!$createdUser instanceof User || !$createdUser->id) {
-			$createdUser = wire('users')->get($createdUser);
-		}
-		if (!$this->isCreatedUserValid($createdUser)) {
-			throw new ApplicationException('No valid user');
-		}
-		$this->createdUser = $createdUser;
-		return $this->createdUser;
-	}
-
-	public function isCreatedUserValid($value = false) {
-		if ($value === false) {
-			$value = $this->createdUser;
-		}
-		return $value instanceof User && $value->id;
-	}
-
-	public function getCreatedUser() {
-		if (!$this->isCreatedUserValid()) {
-			return wire('users')->getGuestUser();
-		}
-		return $this->createdUser;
-	}
-
-	public function getCreatedUserLink() {
-		$createdUser = $this->getCreatedUser();
-		$createdUserString = $createdUser->name . ' (' . $createdUser->id . ')';
-		if ($createdUser->editable()) {
-			$createdUserString = '<a href="' . $createdUser->editUrl . '" target="_blank">' . $createdUserString . '</a>';
-		}
-		return $createdUserString;
-	}
-
-	public function ___setModified($modified) {
-		if (is_string($modified)) {
-			$modified = strtotime($modified);
-		}
-
-		if (!$this->isModifiedValid($modified)) {
-			throw new ApplicationException('No valid modified date');
-		}
-
-		$this->modified = $modified;
-		return $this->modified;
-	}
-
-	public function isModifiedValid($value = false) {
-		if ($value === false) {
-			$value = $this->modified;
-		}
-		return is_integer($value) && $value > 0;
-	}
-
-	public function getModified() {
-		return $this->modified;
-	}
-
-	public function ___setModifiedUser($modifiedUser) {
-		if (!$modifiedUser instanceof User || !$modifiedUser->id) {
-			$modifiedUser = wire('users')->get($modifiedUser);
-		}
-		if (!$this->isModifiedUserValid($modifiedUser)) {
-			throw new ApplicationException('No valid user');
-		}
-		$this->modifiedUser = $modifiedUser;
-		return $this->modifiedUser;
-	}
-
-	public function isModifiedUserValid($value = false) {
-		if ($value === false) {
-			$value = $this->modifiedUser;
-		}
-		return $value instanceof User && $value->id;
-	}
-
-	public function getModifiedUser() {
-		if (!$this->isModifiedUserValid()) {
-			return wire('users')->getGuestUser();
-		}
-		return $this->modifiedUser;
-	}
-
-	public function getModifiedUserLink() {
-		$modifiedUser = $this->getModifiedUser();
-		$modifiedUserString = $modifiedUser->name . ' (' . $modifiedUser->id . ')';
-		if ($modifiedUser->editable()) {
-			$modifiedUserString = '<a href="' . $modifiedUser->editUrl . '" target="_blank">' . $modifiedUserString . '</a>';
-		}
-		return $modifiedUserString;
-	}
-
-	public function ___setTitle($title) {
-		$title = $this->sanitizer->text($title);
-		if (!$this->isTitleValid($title)) {
-			throw new ApplicationException('No valid title');
-		}
-		$this->title = $title;
-		if ($this->initiated) {
-			$this->modified = time();
-			$this->modifiedUser = $this->wire('user');
-		}
-		return $this->title;
-	}
-
-	public function isTitleValid($value = false) {
-		if ($value === false) {
-			$value = $this->title;
-		}
-		return is_string($value) && strlen($value) > 0;
-	}
-
-	public function getTitle() {
-		return $this->title;
-	}
-
-	public function ___setDescription($description) {
-		$description = $this->sanitizer->textarea($description);
-		if (!$this->isDescriptionValid($description)) {
-			throw new ApplicationException('No valid description');
-		}
-		$this->description = $description;
-		if ($this->initiated) {
-			$this->modified = time();
-			$this->modifiedUser = $this->wire('user');
-		}
-		return $this->description;
-	}
-
-	public function isDescriptionValid($value = false) {
-		if ($value === false) {
-			$value = $this->description;
-		}
-		return is_string($value);
-	}
-
-	public function getDescription() {
-		return $this->description;
-	}
-
-	public function ___setTokenSecret($tokenSecret) {
-		if (!$this->isTokenSecretValid($tokenSecret)) {
-			throw new ApplicationException('No valid token secret');
-		}
-		$this->tokenSecret = $tokenSecret;
-		if ($this->initiated) {
-			$this->modified = time();
-			$this->modifiedUser = $this->wire('user');
-		}
-		return $this->tokenSecret;
-	}
-
-	public function isTokenSecretValid($value = false) {
-		if ($value === false) {
-			$value = $this->tokenSecret;
-		}
-		return is_string($value) && strlen($value) > 10;
-	}
-
-	public function ___regenerateTokenSecret($length = 42) {
-		$this->tokenSecret = AppApiHelper::generateRandomString($length, false);
-	}
-
-	public function getTokenSecret() {
-		return $this->tokenSecret;
-	}
-
-	public function ___setAccesstokenSecret($accesstokenSecret) {
-		if (!$this->isAccesstokenSecretValid($accesstokenSecret)) {
-			throw new ApplicationException('No valid access token secret');
-		}
-		$this->accesstokenSecret = $accesstokenSecret;
-		if ($this->initiated) {
-			$this->modified = time();
-			$this->modifiedUser = $this->wire('user');
-		}
-		return $this->accesstokenSecret;
-	}
-
-	public function isAccesstokenSecretValid($value = false) {
-		if ($value === false) {
-			$value = $this->accesstokenSecret;
-		}
-		return is_string($value) && strlen($value) > 10;
-	}
-
-	public function regenerateAccesstokenSecret($length = 30) {
-		$this->accesstokenSecret = AppApiHelper::generateRandomString($length, false);
-	}
-
-	public function getAccesstokenSecret() {
-		return $this->accesstokenSecret;
-	}
-
-	public function ___setDefaultApplication($defaultApplication) {
-		$this->defaultApplication = !!$defaultApplication && $defaultApplication !== 0;
-		if ($this->initiated) {
-			$this->modified = time();
-			$this->modifiedUser = $this->wire('user');
-		}
-		return $this->defaultApplication;
-	}
-
-	public function isDefaultApplicationValid($value = false) {
-		return true;
-	}
-
-	public function isDefaultApplication() {
-		return !!$this->defaultApplication;
-	}
-
-	public function ___setExpiresIn($expiresIn) {
-		if (is_string($expiresIn)) {
-			$expiresIn = intval($expiresIn);
-		}
-		if (!$this->isExpiresInValid($expiresIn)) {
-			throw new ApplicationException('No valid expires in value');
-		}
-		$this->expiresIn = $expiresIn;
-		if ($this->initiated) {
-			$this->modified = time();
-			$this->modifiedUser = $this->wire('user');
-		}
-		return $this->expiresIn;
-	}
-
-	public function isExpiresInValid($value = false) {
-		if ($value === false) {
-			$value = $this->expiresIn;
-		}
-		return is_integer($value) && $value > 0;
-	}
-
-	public function getExpiresIn() {
-		return $this->expiresIn;
-	}
-
-	public function ___setAuthtype($authtype) {
-		$authtype = $this->sanitizer->int($authtype);
-		if (!$this->isAuthtypeValid($authtype)) {
-			throw new ApplicationException('No valid authtype');
-		}
-		$this->authtype = $authtype;
-		if ($this->initiated) {
-			$this->modified = time();
-			$this->modifiedUser = $this->wire('user');
-		}
-		return $this->authtype;
-	}
-
-	public function isAuthtypeValid($value = false) {
-		if ($value === false) {
-			$value = $this->authtype;
-		}
-		return $value >= 0 && $value <= 2;
-	}
-
-	public function getAuthtype() {
-		return $this->authtype;
-	}
-
-	public function ___setLogintype($logintype) {
-		$logintype = $this->sanitizer->options($logintype, self::logintypeOptions);
-		if (!$this->isLogintypeValid($logintype)) {
-			throw new ApplicationException('No valid logintype');
-		}
-		$this->logintype = $logintype;
-		if ($this->initiated) {
-			$this->modified = time();
-			$this->modifiedUser = $this->wire('user');
-		}
-		return $this->logintype;
-	}
-
-	public function isLogintypeValid($value = []) {
-		if (!count($value)) {
-			$value = $this->logintype;
-		}
-		return !!count($value);
-	}
-
-	public function getLogintype() {
-		return $this->logintype;
-	}
-
-	public function ___getApikeys() {
-		if ($this->isNew()) {
-			return new WireArray();
-		}
-
-		$apikeys = new WireArray();
-		$db = wire('database');
-		$query = $db->prepare('SELECT * FROM ' . AppApi::tableApikeys . ' WHERE `application_id`=:application_id;');
-		$query->closeCursor();
-		$query->execute([
-			':application_id' => $this->getID()
-		]);
-		$queueRaw = $query->fetchAll(\PDO::FETCH_ASSOC);
-
-		foreach ($queueRaw as $queueItem) {
-			if (!isset($queueItem['id']) || empty($queueItem['id'])) {
-				continue;
-			}
-
-			try {
-				$apikey = new Apikey($queueItem);
-				if ($apikey->isValid()) {
-					$apikeys->add($apikey);
-				}
-			} catch (\Exception $e) {
-			}
-		}
-		return $apikeys;
-	}
-
-	public function ___getApikey($key) {
-		if ($key instanceof Apikey) {
-			$key = $key->getKey();
-		}
-		return $this->getApikeys()->findOne('key=' . $key);
-	}
-
-	public function ___hasApikey($key) {
-		return $this->getApikey($key) instanceof Apikey;
-	}
-
-	public function ___removeApikey($key) {
-		if ($key instanceof Apikey) {
-			$key = $key->getKey();
-		}
-		$apikey = $this->getApikey($key);
-		if (!$apikey instanceof Apikey) {
-			return true;
-		}
-
-		return $apikey->delete();
-	}
-
-	public function ___getApptokens() {
-		if ($this->isNew()) {
-			return new WireArray();
-		}
-
-		$apptokens = new WireArray();
-		$db = wire('database');
-		$query = $db->prepare('SELECT * FROM ' . AppApi::tableApptokens . ' WHERE `application_id`=:application_id;');
-		$query->closeCursor();
-		$query->execute([
-			':application_id' => $this->getID()
-		]);
-		$queueRaw = $query->fetchAll(\PDO::FETCH_ASSOC);
-
-		foreach ($queueRaw as $queueItem) {
-			if (!isset($queueItem['id']) || empty($queueItem['id'])) {
-				continue;
-			}
-
-			try {
-				$apptoken = new Apptoken($queueItem);
-				if ($apptoken->isValid()) {
-					$apptokens->add($apptoken);
-				}
-			} catch (\Exception $e) {
-			}
-		}
-		return $apptokens;
-	}
-
-	public function ___getApptoken($tokenID) {
-		try {
-			$db = wire('database');
-			$query = $db->prepare('SELECT * FROM ' . AppApi::tableApptokens . ' WHERE `token_id`=:token_id AND `application_id`=:application_id;');
-			$query->closeCursor();
-
-			$query->execute([
-				':token_id' => $tokenID,
-				':application_id' => $this->getID()
-			]);
-			$queueRaw = $query->fetch(\PDO::FETCH_ASSOC);
-
-			return new Apptoken($queueRaw);
-		} catch (\Exception $e) {
-			throw $e;
-			return false;
-		}
-
-		return false;
-	}
-
-	/**
-	 * Deletes the application and all associated apikeys & tokens
-	 *
-	 * @return boolean
-	 */
-	public function ___delete() {
-		if ($this->isNew()) {
-			return true;
-		}
-
-		try {
-			$db = wire('database');
-			$queryVars = [
-				':id' => $this->getID()
-			];
-
-			$preparedQuery = 'DELETE FROM `' . AppApi::tableApikeys . '` WHERE `application_id`=:id;';
-			$preparedQuery .= 'DELETE FROM `' . AppApi::tableApptokens . '` WHERE `application_id`=:id;';
-			$preparedQuery .= 'DELETE FROM `' . AppApi::tableApplications . '` WHERE `id`=:id;';
-
-			$query = $db->prepare($preparedQuery);
-			$query->closeCursor();
-			$query->execute($queryVars);
-		} catch (\Exception $e) {
-			return false;
-		}
-
-		return true;
-	}
-
-	public function ___save() {
-		if (!$this->isSaveable()) {
-			return false;
-		}
-
-		$db = wire('database');
-		$queryVars = [
-			':created_user_id' => $this->getCreatedUser()->id,
-			':created' => date('Y-m-d G:i:s', $this->getCreated() === null ? 0 : $this->getCreated()),
-			':modified_user_id' => $this->getModifiedUser()->id,
-			':modified' => date('Y-m-d G:i:s', $this->getModified() === null ? 0 : $this->getModified()),
-			':title' => $this->getTitle(),
-			':description' => $this->getDescription(),
-			':default_application' => $this->isDefaultApplication() ? 1 : 0,
-			':token_secret' => $this->getTokenSecret(),
-			':accesstoken_secret' => $this->getAccesstokenSecret(),
-			':authtype' => $this->getAuthtype(),
-			':logintype' => json_encode($this->getLogintype()),
-			':expires_in' => $this->getExpiresIn()
-		];
-
-		if (!$this->isNew()) {
-			// This application already exists in db and shall be updated.
-
-			$queryVars[':id'] = $this->getID();
-
-			try {
-				$updateStatement = 'UPDATE `' . AppApi::tableApplications . '` SET `created_user_id`=:created_user_id, `created`=:created, `modified_user_id`=:modified_user_id, `modified`=:modified, `title`=:title, `description`=:description, `default_application`=:default_application, `token_secret`=:token_secret, `accesstoken_secret`=:accesstoken_secret, `authtype`=:authtype, `logintype`=:logintype, `expires_in`=:expires_in WHERE `id`=:id;';
-				if ($this->isDefaultApplication()) {
-					$updateStatement .= 'UPDATE `' . AppApi::tableApplications . '` SET `default_application`=0 WHERE `id`!=:id;';
-				}
-
-				$query = $db->prepare($updateStatement);
-				$query->closeCursor();
-				$query->execute($queryVars);
-			} catch (\Exception $e) {
-				$this->error('The application [' . $this->getID() . '] could not be saved: ' . $e->getMessage());
-				return false;
-			}
-
-			return true;
-		}
-
-		// New application should be saved into db:
-		try {
-			$createStatement = 'INSERT INTO `' . AppApi::tableApplications . '` (`id`, `created_user_id`, `created`,`modified_user_id`, `modified`, `title`, `description`, `default_application`, `token_secret`, `accesstoken_secret`, `authtype`, `logintype`, `expires_in`) VALUES (NULL, :created_user_id, :created, :modified_user_id, :modified, :title, :description, :default_application, :token_secret, :accesstoken_secret, :authtype, :logintype, :expires_in);';
-			if ($this->isDefaultApplication()) {
-				$createStatement .= 'UPDATE `' . AppApi::tableApplications . '` SET `default_application`=0 WHERE `id`!=:id;';
-			}
-
-			$query = $db->prepare($createStatement);
-			$query->closeCursor();
-			$query->execute($queryVars);
-			$this->id = $db->lastInsertId();
-		} catch (\Exception $e) {
-			$this->error('The application could not be saved: ' . $e->getMessage());
-			return false;
-		}
-
-		return true;
-	}
+   private $initiated = false;
+   protected $id;
+   protected $title;
+   protected $description;
+   protected $created;
+   protected $createdUser;
+   protected $modified;
+   protected $modifiedUser;
+
+   protected $tokenSecret;
+   protected $accesstokenSecret;
+
+   protected $defaultApplication;
+   protected $expiresIn;
+
+   protected $authtype = 0;
+
+   /*
+    * A normal website-application can be used to access public data with only a valid apikey. Protected data will be authorized with classic php-sessions. If you are logged in, you can use protected apipages.
+    */
+   const authtypeSession = 0;
+
+   /**
+    * A protected website-application shows contents only if you have a valid JWT-token that authorizes you to use an endpoint. A JWT-token should be requested via PHP and has to be transferred to JS on pageload (e.g. as a special data-attribute). It can be limited to only those special endpoints that the api function uses. The JWT-token is linked to the php-session so it has a limited livetime. With protectedWebsite-endpoints we can prevent that api-access via token can be used for general apicalls from other services.
+    */
+   const authtypeSingleJWT = 1;
+
+   /*
+    * A classic app allows users to log in and authenticate via refresh- and access-tokens afterwards. Public contents are available with only a valid apikey.
+    */
+   const authtypeDoubleJWT = 2;
+
+   /*
+    * A secure double JWT saves the refresh_token in a secure httpOnly cookie that the client app cant access via JS, it gets sent automatically with every request 
+    * and is validated to provide an access_token, which the client app doesnt need to store anywhere and can live safely in a memory state where an atacker cant access it, 
+    * allows users to access via refresh- and access-tokens afterwards. Public contents are available with only a valid apikey.
+    */
+   const authtypeDoubleJWTsecure = 3;
+
+   public static function getAuthtypeLabel($authtype) {
+      if ($authtype === self::authtypeSession) {
+         return __('PHP Session');
+      } elseif ($authtype === self::authtypeSingleJWT) {
+         return __('Single JWT');
+      } elseif ($authtype === self::authtypeDoubleJWT) {
+         return __('Double JWT');
+      } elseif ($authtype === self::authtypeDoubleJWTsecure) {
+         return __('Double JWT (secure)');
+      }
+      return 'Unknown: ' . $authtype;
+   }
+
+   const logintypeOptions = [
+      'logintypeUsernamePassword',
+      'logintypeEmailPassword'
+   ];
+
+   protected $logintype = ['logintypeUsernamePassword'];
+
+
+   public static function getLogintypeLabel($logintype) {
+      if ($logintype === self::logintypeOptions[0]) {
+         return __('Username sign-in');
+      } elseif ($logintype === self::logintypeOptions[1]) {
+         return __('Email sign-in');
+      }
+      return 'Unknown: ' . $loginype;
+   }
+
+
+   public function __construct(array $import = []) {
+      $this->id = null;
+      $this->created = time();
+      $this->createdUser = null;
+      $this->modified = time();
+      $this->modifiedUser = null;
+      $this->title = '';
+      $this->description = '';
+      $this->defaultApplication = false;
+
+      $this->tokenSecret = '';
+      $this->accesstokenSecret = '';
+
+      $this->expiresIn = 30 * 24 * 60 * 60; // default: 30 days
+
+      if (is_array($import) && wireCount($import) > 0) {
+         $this->import($import);
+      }
+      if ($this->isNew()) {
+         $this->created = time();
+         $this->createdUser = $this->wire('user');
+         $this->modified = time();
+         $this->modifiedUser = $this->wire('user');
+      }
+      $this->initiated = true;
+   }
+
+   protected function import(array $values) {
+
+      if (!isset($values['id'])) {
+         throw new ApplicationException('You cannot import an application without an id.');
+      }
+      $this->id = (int) $values['id'];
+
+      if (isset($values['created'])) {
+         $this->___setCreated($values['created']);
+      }
+      if (isset($values['created_user_id'])) {
+         $this->___setCreatedUser($values['created_user_id']);
+      }
+
+      if (isset($values['modified'])) {
+         $this->___setModified($values['modified']);
+      }
+      if (isset($values['modified_user_id'])) {
+         $this->___setModifiedUser($values['modified_user_id']);
+      }
+
+      if (isset($values['title'])) {
+         $this->___setTitle($values['title']);
+      }
+
+      if (isset($values['description'])) {
+         $this->___setDescription($values['description']);
+      }
+
+      if (isset($values['default_application'])) {
+         $this->___setDefaultApplication($values['default_application']);
+      }
+
+      if (isset($values['token_secret'])) {
+         $this->___setTokenSecret($values['token_secret']);
+      }
+
+      if (isset($values['accesstoken_secret'])) {
+         $this->___setAccesstokenSecret($values['accesstoken_secret']);
+      }
+
+      if (isset($values['authtype'])) {
+         $this->___setAuthtype($values['authtype']);
+      }
+
+      if (isset($values['logintype']) && !!json_decode($values['logintype'])) {
+         $this->___setLogintype(json_decode($values['logintype']));
+      }
+
+      if (isset($values['expires_in'])) {
+         $this->___setExpiresIn($values['expires_in']);
+      }
+   }
+
+   public function ___isSaveable() {
+      if (!$this->isValid()) {
+         return false;
+      }
+      return true;
+   }
+
+   public function ___isValid() {
+      return $this->isIDValid() && $this->isCreatedValid() && $this->isCreatedUserValid() && $this->isModifiedValid() && $this->isModifiedUserValid() && $this->isTitleValid() && $this->isDescriptionValid() && $this->isTokenSecretValid() && $this->isAccesstokenSecretValid() && $this->isAuthtypeValid() && $this->isLogintypeValid() && $this->isExpiresInValid() && $this->isDefaultApplicationValid();
+   }
+
+   public function ___isNew() {
+      return empty($this->id);
+   }
+
+   public function getID() {
+      return $this->id;
+   }
+
+   public function isIDValid($value = false) {
+      if ($value === false) {
+         $value = $this->id;
+      }
+      return $value === null || (is_integer($value) && $value >= 0);
+   }
+
+   public function ___setCreated($created) {
+      if (is_string($created)) {
+         $created = strtotime($created);
+      }
+
+      if (!$this->isCreatedValid($created)) {
+         throw new ApplicationException('No valid modified date');
+      }
+
+      $this->created = $created;
+      return $this->created;
+   }
+
+   public function isCreatedValid($value = false) {
+      if ($value === false) {
+         $value = $this->created;
+      }
+      return is_integer($value) && $value > 0;
+   }
+
+   public function getCreated() {
+      return $this->created;
+   }
+
+   public function ___setCreatedUser($createdUser) {
+      if (!$createdUser instanceof User || !$createdUser->id) {
+         $createdUser = wire('users')->get($createdUser);
+      }
+      if (!$this->isCreatedUserValid($createdUser)) {
+         throw new ApplicationException('No valid user');
+      }
+      $this->createdUser = $createdUser;
+      return $this->createdUser;
+   }
+
+   public function isCreatedUserValid($value = false) {
+      if ($value === false) {
+         $value = $this->createdUser;
+      }
+      return $value instanceof User && $value->id;
+   }
+
+   public function getCreatedUser() {
+      if (!$this->isCreatedUserValid()) {
+         return wire('users')->getGuestUser();
+      }
+      return $this->createdUser;
+   }
+
+   public function getCreatedUserLink() {
+      $createdUser = $this->getCreatedUser();
+      $createdUserString = $createdUser->name . ' (' . $createdUser->id . ')';
+      if ($createdUser->editable()) {
+         $createdUserString = '<a href="' . $createdUser->editUrl . '" target="_blank">' . $createdUserString . '</a>';
+      }
+      return $createdUserString;
+   }
+
+   public function ___setModified($modified) {
+      if (is_string($modified)) {
+         $modified = strtotime($modified);
+      }
+
+      if (!$this->isModifiedValid($modified)) {
+         throw new ApplicationException('No valid modified date');
+      }
+
+      $this->modified = $modified;
+      return $this->modified;
+   }
+
+   public function isModifiedValid($value = false) {
+      if ($value === false) {
+         $value = $this->modified;
+      }
+      return is_integer($value) && $value > 0;
+   }
+
+   public function getModified() {
+      return $this->modified;
+   }
+
+   public function ___setModifiedUser($modifiedUser) {
+      if (!$modifiedUser instanceof User || !$modifiedUser->id) {
+         $modifiedUser = wire('users')->get($modifiedUser);
+      }
+      if (!$this->isModifiedUserValid($modifiedUser)) {
+         throw new ApplicationException('No valid user');
+      }
+      $this->modifiedUser = $modifiedUser;
+      return $this->modifiedUser;
+   }
+
+   public function isModifiedUserValid($value = false) {
+      if ($value === false) {
+         $value = $this->modifiedUser;
+      }
+      return $value instanceof User && $value->id;
+   }
+
+   public function getModifiedUser() {
+      if (!$this->isModifiedUserValid()) {
+         return wire('users')->getGuestUser();
+      }
+      return $this->modifiedUser;
+   }
+
+   public function getModifiedUserLink() {
+      $modifiedUser = $this->getModifiedUser();
+      $modifiedUserString = $modifiedUser->name . ' (' . $modifiedUser->id . ')';
+      if ($modifiedUser->editable()) {
+         $modifiedUserString = '<a href="' . $modifiedUser->editUrl . '" target="_blank">' . $modifiedUserString . '</a>';
+      }
+      return $modifiedUserString;
+   }
+
+   public function ___setTitle($title) {
+      $title = $this->sanitizer->text($title);
+      if (!$this->isTitleValid($title)) {
+         throw new ApplicationException('No valid title');
+      }
+      $this->title = $title;
+      if ($this->initiated) {
+         $this->modified = time();
+         $this->modifiedUser = $this->wire('user');
+      }
+      return $this->title;
+   }
+
+   public function isTitleValid($value = false) {
+      if ($value === false) {
+         $value = $this->title;
+      }
+      return is_string($value) && strlen($value) > 0;
+   }
+
+   public function getTitle() {
+      return $this->title;
+   }
+
+   public function ___setDescription($description) {
+      $description = $this->sanitizer->textarea($description);
+      if (!$this->isDescriptionValid($description)) {
+         throw new ApplicationException('No valid description');
+      }
+      $this->description = $description;
+      if ($this->initiated) {
+         $this->modified = time();
+         $this->modifiedUser = $this->wire('user');
+      }
+      return $this->description;
+   }
+
+   public function isDescriptionValid($value = false) {
+      if ($value === false) {
+         $value = $this->description;
+      }
+      return is_string($value);
+   }
+
+   public function getDescription() {
+      return $this->description;
+   }
+
+   public function ___setTokenSecret($tokenSecret) {
+      if (!$this->isTokenSecretValid($tokenSecret)) {
+         throw new ApplicationException('No valid token secret');
+      }
+      $this->tokenSecret = $tokenSecret;
+      if ($this->initiated) {
+         $this->modified = time();
+         $this->modifiedUser = $this->wire('user');
+      }
+      return $this->tokenSecret;
+   }
+
+   public function isTokenSecretValid($value = false) {
+      if ($value === false) {
+         $value = $this->tokenSecret;
+      }
+      return is_string($value) && strlen($value) > 10;
+   }
+
+   public function ___regenerateTokenSecret($length = 42) {
+      $this->tokenSecret = AppApiHelper::generateRandomString($length, false);
+   }
+
+   public function getTokenSecret() {
+      return $this->tokenSecret;
+   }
+
+   public function ___setAccesstokenSecret($accesstokenSecret) {
+      if (!$this->isAccesstokenSecretValid($accesstokenSecret)) {
+         throw new ApplicationException('No valid access token secret');
+      }
+      $this->accesstokenSecret = $accesstokenSecret;
+      if ($this->initiated) {
+         $this->modified = time();
+         $this->modifiedUser = $this->wire('user');
+      }
+      return $this->accesstokenSecret;
+   }
+
+   public function isAccesstokenSecretValid($value = false) {
+      if ($value === false) {
+         $value = $this->accesstokenSecret;
+      }
+      return is_string($value) && strlen($value) > 10;
+   }
+
+   public function regenerateAccesstokenSecret($length = 30) {
+      $this->accesstokenSecret = AppApiHelper::generateRandomString($length, false);
+   }
+
+   public function getAccesstokenSecret() {
+      return $this->accesstokenSecret;
+   }
+
+   public function ___setDefaultApplication($defaultApplication) {
+      $this->defaultApplication = !!$defaultApplication && $defaultApplication !== 0;
+      if ($this->initiated) {
+         $this->modified = time();
+         $this->modifiedUser = $this->wire('user');
+      }
+      return $this->defaultApplication;
+   }
+
+   public function isDefaultApplicationValid($value = false) {
+      return true;
+   }
+
+   public function isDefaultApplication() {
+      return !!$this->defaultApplication;
+   }
+
+   public function ___setExpiresIn($expiresIn) {
+      if (is_string($expiresIn)) {
+         $expiresIn = intval($expiresIn);
+      }
+      if (!$this->isExpiresInValid($expiresIn)) {
+         throw new ApplicationException('No valid expires in value');
+      }
+      $this->expiresIn = $expiresIn;
+      if ($this->initiated) {
+         $this->modified = time();
+         $this->modifiedUser = $this->wire('user');
+      }
+      return $this->expiresIn;
+   }
+
+   public function isExpiresInValid($value = false) {
+      if ($value === false) {
+         $value = $this->expiresIn;
+      }
+      return is_integer($value) && $value > 0;
+   }
+
+   public function getExpiresIn() {
+      return $this->expiresIn;
+   }
+
+   public function ___setAuthtype($authtype) {
+      $authtype = $this->sanitizer->int($authtype);
+      if (!$this->isAuthtypeValid($authtype)) {
+         throw new ApplicationException('No valid authtype');
+      }
+      $this->authtype = $authtype;
+      if ($this->initiated) {
+         $this->modified = time();
+         $this->modifiedUser = $this->wire('user');
+      }
+      return $this->authtype;
+   }
+
+   public function isAuthtypeValid($value = false) {
+      if ($value === false) {
+         $value = $this->authtype;
+      }
+      return $value >= 0 && $value <= 3;
+   }
+
+   public function getAuthtype() {
+      return $this->authtype;
+   }
+
+   public function ___setLogintype($logintype) {
+      $logintype = $this->sanitizer->options($logintype, self::logintypeOptions);
+      if (!$this->isLogintypeValid($logintype)) {
+         throw new ApplicationException('No valid logintype');
+      }
+      $this->logintype = $logintype;
+      if ($this->initiated) {
+         $this->modified = time();
+         $this->modifiedUser = $this->wire('user');
+      }
+      return $this->logintype;
+   }
+
+   public function isLogintypeValid($value = []) {
+      if (!count($value)) {
+         $value = $this->logintype;
+      }
+      return !!count($value);
+   }
+
+   public function getLogintype() {
+      return $this->logintype;
+   }
+
+   public function ___getApikeys() {
+      if ($this->isNew()) {
+         return new WireArray();
+      }
+
+      $apikeys = new WireArray();
+      $db = wire('database');
+      $query = $db->prepare('SELECT * FROM ' . AppApi::tableApikeys . ' WHERE `application_id`=:application_id;');
+      $query->closeCursor();
+      $query->execute([
+         ':application_id' => $this->getID()
+      ]);
+      $queueRaw = $query->fetchAll(\PDO::FETCH_ASSOC);
+
+      foreach ($queueRaw as $queueItem) {
+         if (!isset($queueItem['id']) || empty($queueItem['id'])) {
+            continue;
+         }
+
+         try {
+            $apikey = new Apikey($queueItem);
+            if ($apikey->isValid()) {
+               $apikeys->add($apikey);
+            }
+         } catch (\Exception $e) {
+         }
+      }
+      return $apikeys;
+   }
+
+   public function ___getApikey($key) {
+      if ($key instanceof Apikey) {
+         $key = $key->getKey();
+      }
+      return $this->getApikeys()->findOne('key=' . $key);
+   }
+
+   public function ___hasApikey($key) {
+      return $this->getApikey($key) instanceof Apikey;
+   }
+
+   public function ___removeApikey($key) {
+      if ($key instanceof Apikey) {
+         $key = $key->getKey();
+      }
+      $apikey = $this->getApikey($key);
+      if (!$apikey instanceof Apikey) {
+         return true;
+      }
+
+      return $apikey->delete();
+   }
+
+   public function ___getApptokens() {
+      if ($this->isNew()) {
+         return new WireArray();
+      }
+
+      $apptokens = new WireArray();
+      $db = wire('database');
+      $query = $db->prepare('SELECT * FROM ' . AppApi::tableApptokens . ' WHERE `application_id`=:application_id;');
+      $query->closeCursor();
+      $query->execute([
+         ':application_id' => $this->getID()
+      ]);
+      $queueRaw = $query->fetchAll(\PDO::FETCH_ASSOC);
+
+      foreach ($queueRaw as $queueItem) {
+         if (!isset($queueItem['id']) || empty($queueItem['id'])) {
+            continue;
+         }
+
+         try {
+            $apptoken = new Apptoken($queueItem);
+            if ($apptoken->isValid()) {
+               $apptokens->add($apptoken);
+            }
+         } catch (\Exception $e) {
+         }
+      }
+      return $apptokens;
+   }
+
+   public function ___getApptoken($tokenID) {
+      try {
+         $db = wire('database');
+         $query = $db->prepare('SELECT * FROM ' . AppApi::tableApptokens . ' WHERE `token_id`=:token_id AND `application_id`=:application_id;');
+         $query->closeCursor();
+
+         $query->execute([
+            ':token_id' => $tokenID,
+            ':application_id' => $this->getID()
+         ]);
+         $queueRaw = $query->fetch(\PDO::FETCH_ASSOC);
+
+         return new Apptoken($queueRaw);
+      } catch (\Exception $e) {
+         throw $e;
+         return false;
+      }
+
+      return false;
+   }
+
+   /**
+    * Deletes the application and all associated apikeys & tokens
+    *
+    * @return boolean
+    */
+   public function ___delete() {
+      if ($this->isNew()) {
+         return true;
+      }
+
+      try {
+         $db = wire('database');
+         $queryVars = [
+            ':id' => $this->getID()
+         ];
+
+         $preparedQuery = 'DELETE FROM `' . AppApi::tableApikeys . '` WHERE `application_id`=:id;';
+         $preparedQuery .= 'DELETE FROM `' . AppApi::tableApptokens . '` WHERE `application_id`=:id;';
+         $preparedQuery .= 'DELETE FROM `' . AppApi::tableApplications . '` WHERE `id`=:id;';
+
+         $query = $db->prepare($preparedQuery);
+         $query->closeCursor();
+         $query->execute($queryVars);
+      } catch (\Exception $e) {
+         return false;
+      }
+
+      return true;
+   }
+
+   public function ___save() {
+      if (!$this->isSaveable()) {
+         return false;
+      }
+
+      $db = wire('database');
+      $queryVars = [
+         ':created_user_id' => $this->getCreatedUser()->id,
+         ':created' => date('Y-m-d G:i:s', $this->getCreated() === null ? 0 : $this->getCreated()),
+         ':modified_user_id' => $this->getModifiedUser()->id,
+         ':modified' => date('Y-m-d G:i:s', $this->getModified() === null ? 0 : $this->getModified()),
+         ':title' => $this->getTitle(),
+         ':description' => $this->getDescription(),
+         ':default_application' => $this->isDefaultApplication() ? 1 : 0,
+         ':token_secret' => $this->getTokenSecret(),
+         ':accesstoken_secret' => $this->getAccesstokenSecret(),
+         ':authtype' => $this->getAuthtype(),
+         ':logintype' => json_encode($this->getLogintype()),
+         ':expires_in' => $this->getExpiresIn()
+      ];
+
+      if (!$this->isNew()) {
+         // This application already exists in db and shall be updated.
+
+         $queryVars[':id'] = $this->getID();
+
+         try {
+            $updateStatement = 'UPDATE `' . AppApi::tableApplications . '` SET `created_user_id`=:created_user_id, `created`=:created, `modified_user_id`=:modified_user_id, `modified`=:modified, `title`=:title, `description`=:description, `default_application`=:default_application, `token_secret`=:token_secret, `accesstoken_secret`=:accesstoken_secret, `authtype`=:authtype, `logintype`=:logintype, `expires_in`=:expires_in WHERE `id`=:id;';
+            if ($this->isDefaultApplication()) {
+               $updateStatement .= 'UPDATE `' . AppApi::tableApplications . '` SET `default_application`=0 WHERE `id`!=:id;';
+            }
+
+            $query = $db->prepare($updateStatement);
+            $query->closeCursor();
+            $query->execute($queryVars);
+         } catch (\Exception $e) {
+            $this->error('The application [' . $this->getID() . '] could not be saved: ' . $e->getMessage());
+            return false;
+         }
+
+         return true;
+      }
+
+      // New application should be saved into db:
+      try {
+         $createStatement = 'INSERT INTO `' . AppApi::tableApplications . '` (`id`, `created_user_id`, `created`,`modified_user_id`, `modified`, `title`, `description`, `default_application`, `token_secret`, `accesstoken_secret`, `authtype`, `logintype`, `expires_in`) VALUES (NULL, :created_user_id, :created, :modified_user_id, :modified, :title, :description, :default_application, :token_secret, :accesstoken_secret, :authtype, :logintype, :expires_in);';
+         if ($this->isDefaultApplication()) {
+            $createStatement .= 'UPDATE `' . AppApi::tableApplications . '` SET `default_application`=0 WHERE `id`!=:id;';
+         }
+
+         $query = $db->prepare($createStatement);
+         $query->closeCursor();
+         $query->execute($queryVars);
+         $this->id = $db->lastInsertId();
+      } catch (\Exception $e) {
+         $this->error('The application could not be saved: ' . $e->getMessage());
+         return false;
+      }
+
+      return true;
+   }
 }

--- a/classes/Auth.php
+++ b/classes/Auth.php
@@ -7,629 +7,731 @@ require_once __DIR__ . '/AppApiHelper.php';
 use \Firebase\JWT\JWT;
 
 class Auth extends WireData {
-	protected $apikey = false;
-	protected $application = false;
-
-	// Only needed for logging:
-	protected $tokenId = false;
-
-	public function ___initApikey() {
-		$headers = AppApiHelper::getRequestHeaders();
-		$tokenFromGet = $_GET && isset($_GET['api_key']) ? $_GET['api_key'] : '';
-
-		if (!empty($headers['X-API-KEY']) || !empty($tokenFromGet)) {
-			$apikey = !empty($headers['X-API-KEY']) ? $headers['X-API-KEY'] : $tokenFromGet;
-			try {
-				// Get apikey-object:
-				$apikeyString = $this->sanitizer->text($apikey);
-				$db = $this->wire('database');
-				$query = $db->prepare('SELECT * FROM ' . AppApi::tableApikeys . ' WHERE `key`=:key;');
-				$query->closeCursor();
-
-				$query->execute([
-					':key' => $apikeyString
-				]);
-				$queueRaw = $query->fetch(\PDO::FETCH_ASSOC);
-				$this->apikey = new Apikey($queueRaw);
-
-				// Get application from apikey:
-				$query = $db->prepare('SELECT * FROM ' . AppApi::tableApplications . ' WHERE `id`=:id;');
-				$query->closeCursor();
-
-				$query->execute([
-					':id' => $this->apikey->getApplicationID()
-				]);
-				$queueRaw = $query->fetch(\PDO::FETCH_ASSOC);
-				$this->application = new Application($queueRaw);
-			} catch (\Throwable $e) {
-			}
-		} else {
-			try {
-				// Get default application that handles requests without an apikey:
-				$db = $this->wire('database');
-				$query = $db->prepare('SELECT * FROM ' . AppApi::tableApplications . ' WHERE `default_application`=true;');
-				$query->closeCursor();
-				$query->execute();
-				$queueRaw = $query->fetch(\PDO::FETCH_ASSOC);
-				if (!$queueRaw || !is_array($queueRaw)) {
-					throw new \Exception('No default application set.');
-				}
-				$this->application = new Application($queueRaw);
-			} catch (\Throwable $e) {
-			}
-		}
-	}
-
-	public function getApplication() {
-		return $this->application;
-	}
-
-	public function isApikeyValid() {
-		return ($this->apikey instanceof Apikey && $this->apikey->isAccessable() && $this->application instanceof Application) || ($this->apikey === false && $this->application instanceof Application);
-	}
-
-	public function getApikeyLog() {
-		if (!$this->isApikeyValid() || !($this->apikey instanceof Apikey)) {
-			return 'Apikey-ID: NONE';
-		}
-		return 'Apikey-ID: ' . $this->apikey->getID();
-	}
-
-	public function getApplicationLog() {
-		if (!$this->application) {
-			return 'Application-ID: NONE';
-		}
-		return 'Application-ID: ' . $this->application->getID();
-	}
-
-	protected function ___createSingleJWTToken($args = []) {
-		if ($this->wire('user')->isGuest()) {
-			throw new AuthException('user is not logged in', 401);
-		}
-
-		$apptoken = new Apptoken($this->application->getID());
-		$apptoken->setUser($this->wire('user'));
-		$apptoken->setExpirationTime(time() + $this->application->getExpiresIn());
-
-		$tokenArgs = [];
-		session_regenerate_id(true);
-		$sessionName = session_name();
-		$sid = $this->wire('input')->cookie($sessionName);
-		if (is_string($sid) && strlen($sid) > 0) {
-			$tokenArgs['sid'] = $sid;
-		}
-
-		$wiresChallengeWert = $this->wire('input')->cookie($sessionName . '_challenge');
-		if (is_string($wiresChallengeWert) && strlen($wiresChallengeWert) > 0) {
-			$tokenArgs['sid_challenge'] = $wiresChallengeWert;
-		}
-
-		$tokenArgs = array_merge($tokenArgs, $args);
-
-		$jwt = $apptoken->getJWT($this->application->getTokenSecret(), $tokenArgs);
-
-		$apptoken->save();
-
-		return $jwt;
-	}
-
-	public function ___doLogin($data) {
-		$access = $this->getLogintype($data);
-		$loggedIn = false;
-		$user = null;
-		$accessMethod = $access['method'];
-		$allowedLoginTypes = $this->application->getLogintype();
-		$params = (object)$access['params'];
-
-		if (
-			in_array($accessMethod, ['username-password', 'any-password']) &&
-			in_array('logintypeUsernamePassword', $allowedLoginTypes)
-		) {
-			// Get login params
-			$username = isset($params->username) ? $params->username : null;
-			$password = isset($params->password) ? $params->password : null;
-
-			if (empty($username) || empty($password)) {
-				throw new AuthException('Login not successful', 401);
-			}
-
-			$user = $this->wire('users')->get('name=' . $username);
-
-			// prevent username sniffing by just throwing a general exception:
-			if ($user->id) {
-				$loggedIn = $this->wire('session')->login($user->name, $password);
-			}
-		}
-
-		if (
-			!$loggedIn &&
-			in_array($accessMethod, ['email-password', 'any-password']) &&
-			in_array('logintypeEmailPassword', $allowedLoginTypes)
-		) {
-			// Get login params
-			$email = isset($params->email) ? $params->email : (isset($params->username) ? $params->username : null);
-			$password = isset($params->password) ? $params->password : null;
-
-			if (empty($email) || empty($password)) {
-				throw new AuthException('Login not successful', 401);
-			}
-
-			$user = $this->wire('users')->get('email=' . $email);
-
-
-			if ($user->id) {
-				$loggedIn = $this->wire('session')->login($user->name, $password);
-			}
-		}
-
-		// prevent username sniffing by just throwing a general exception:
-		if (!$user || !$user->id) {
-			throw new AuthException('Login not successful', 401);
-		}
-
-		if ($loggedIn) {
-			if ($this->application->getAuthtype() === Application::authtypeSession) {
-				return [
-					'success' => true,
-					'username' => $this->wire('user')->name
-				];
-			}
-			if ($this->application->getAuthtype() === Application::authtypeSingleJWT) {
-				return [
-					'jwt' => $this->createSingleJWTToken(),
-					'username' => $this->wire('user')->name
-				];
-			}
-			if ($this->application->getAuthtype() === Application::authtypeDoubleJWT) {
-				return [
-					'refresh_token' => $this->createRefreshToken(),
-					'username' => $this->wire('user')->name
-				];
-			}
-		}
-
-		throw new AuthException('Login not successful', 401);
-	}
-
-	protected function ___createRefreshToken($args = []) {
-		if ($this->wire('user')->isGuest()) {
-			throw new AuthException('user is not logged in', 401);
-		}
-
-		$apptoken = new Apptoken($this->application->getID());
-		$apptoken->setUser($this->wire('user'));
-		$apptoken->setExpirationTime(time() + $this->application->getExpiresIn()); // Refreshtoken is valid for 30 days
-
-		$jwt = $apptoken->getJWT($this->application->getTokenSecret(), $args);
-
-		if (!$apptoken->save()) {
-			throw new InternalServererrorException('Token could not be saved', 500);
-		}
-
-		return $jwt;
-	}
-
-	public function ___getAccessToken() {
-		if ($this->application->getAuthtype() !== Application::authtypeDoubleJWT) {
-			throw new AuthException('Your api-key does not support double-jwt authentication.', 400);
-		}
-
-		$tokenString = $this->getBearerToken();
-		if ($tokenString === null || !is_string($tokenString) || empty($tokenString)) {
-			throw new AuthException('No valid refreshtoken found.', 400);
-		}
-
-		// throws exception if token is invalid:
-		$token = JWT::decode($tokenString, $this->application->getTokenSecret(), ['HS256']);
-		if (!is_object($token)) {
-			throw new AuthException('Invalid Token', 400);
-		}
-
-		$user = $this->wire('users')->get('id=' . $this->wire('sanitizer')->int($token->sub));
-		if (!($user instanceof User) || !$user->id) {
-			throw new AuthException('Invalid User', 400);
-		}
-
-		$refreshtokenFromDB = $this->application->getApptoken($token->jti);
-		if (!$refreshtokenFromDB instanceof Apptoken || !$refreshtokenFromDB->isValid()) {
-			throw new AuthException('Invalid Token', 400);
-		}
-
-		if ($user->isGuest() || $refreshtokenFromDB->getUser()->id !== $user->id) {
-			throw new AuthException('Invalid User', 400);
-		}
-
-		if (!$refreshtokenFromDB->isAccessable()) {
-			throw new RefreshtokenExpiredException();
-		}
-
-		if (!$refreshtokenFromDB->matchesWithJWT($token)) {
-			throw new RefreshtokenExpiredException();
-		}
-
-		$accesstoken = $this->createAccessTokenJWT($user, [
-			'rtkn' => $refreshtokenFromDB->getTokenID()
-		]);
-
-		$refreshtokenFromDB->setExpirationTime(time() + $this->application->getExpiresIn()); // Refreshtoken is valid for 30 days
-		$refreshtokenFromDB->setLastUsed(time());
-		if (!$refreshtokenFromDB->save()) {
-			throw new InternalServererrorException('Token could not be saved', 500);
-		}
-
-		return [
-			'access_token' => $accesstoken,
-			'refresh_token' => $refreshtokenFromDB->getJWT($this->application->getTokenSecret())
-		];
-	}
-
-	protected function ___createAccessTokenJWT(User $user, $args = []) {
-		if ($user->isGuest()) {
-			throw new AuthException('user is not logged in', 401);
-		}
-
-		$apptoken = new Apptoken($this->application->getID());
-		$apptoken->setUser($user);
-		$apptoken->setExpirationTime(time() + $this->wire('config')->sessionExpireSeconds);
-
-		$tokenArgs = [];
-		session_regenerate_id(true);
-		$sessionName = session_name();
-		$wiresWert = $this->wire('input')->cookie($sessionName);
-		if (is_string($wiresWert) && strlen($wiresWert) > 0) {
-			$tokenArgs['sid'] = $wiresWert;
-		}
-
-		$wiresChallengeWert = $this->wire('input')->cookie($sessionName . '_challenge');
-		if (is_string($wiresChallengeWert) && strlen($wiresChallengeWert) > 0) {
-			$tokenArgs['sid_challenge'] = $wiresChallengeWert;
-		}
-
-		$tokenArgs = array_merge($tokenArgs, $args);
-
-		$jwt = $apptoken->getJWT($this->application->getAccesstokenSecret(), $tokenArgs);
-
-		return $jwt;
-	}
-
-	public function ___doLogout() {
-		// Remove Refresh-Token if Double-JWT:
-		try {
-			if ($this->application->getAuthtype() === Application::authtypeDoubleJWT) {
-				$tokenString = $this->getBearerToken();
-				if ($tokenString === null || !is_string($tokenString) || empty($tokenString)) {
-					return false;
-				}
-
-				// throws exception if token is invalid:
-				try {
-					$secret = $this->application->getAccesstokenSecret();
-
-					$token = JWT::decode($tokenString, $secret, ['HS256']);
-				} catch (\Firebase\JWT\ExpiredException $e) {
-					throw new AccesstokenExpiredException();
-				} catch (\Firebase\JWT\BeforeValidException $e) {
-					throw new AccesstokenNotBeforeException();
-				} catch (\Throwable $e) {
-					throw new AccesstokenInvalidException();
-				}
-
-				if (!is_object($token)) {
-					throw new AccesstokenInvalidException();
-				}
-
-				$userid = $this->wire('sanitizer')->int($token->sub);
-				if (empty($userid) || $userid < 1) {
-					throw new AccesstokenInvalidException();
-				}
-
-				$user = $this->wire('users')->get('id=' . $userid);
-				if (!($user instanceof User) || !$user->id) {
-					throw new AccesstokenInvalidException();
-				}
-
-				// Get Refreshtoken that was used to generate this accesstoken:
-				$refreshtokenFromDB = $this->application->getApptoken($token->rtkn);
-				if (!$refreshtokenFromDB instanceof Apptoken || !$refreshtokenFromDB->isValid()) {
-					throw new AccesstokenInvalidException();
-				}
-
-				if ($user->isGuest() || $refreshtokenFromDB->getUser()->id !== $user->id) {
-					throw new AccesstokenInvalidException();
-				}
-
-				if (!$refreshtokenFromDB->matchesWithJWT($token)) {
-					throw new AccesstokenInvalidException();
-				}
-
-				if (!$refreshtokenFromDB->delete()) {
-					throw new InternalServererrorException('Token could not be removed', 500);
-				}
-			}
-		} catch (\Throwable $e) {
-			// todo log
-		}
-
-		$this->wire('session')->logout($this->wire('user'));
-		return [
-			'success' => true
-		];
-	}
-
-	/*------------------------------------*\
+   protected $apikey = false;
+   protected $application = false;
+
+   // Only needed for logging:
+   protected $tokenId = false;
+
+   public function ___initApikey() {
+      $headers = AppApiHelper::getRequestHeaders();
+      $tokenFromGet = $_GET && isset($_GET['api_key']) ? $_GET['api_key'] : '';
+
+      if (!empty($headers['X-API-KEY']) || !empty($tokenFromGet)) {
+         $apikey = !empty($headers['X-API-KEY']) ? $headers['X-API-KEY'] : $tokenFromGet;
+         try {
+            // Get apikey-object:
+            $apikeyString = $this->sanitizer->text($apikey);
+            $db = $this->wire('database');
+            $query = $db->prepare('SELECT * FROM ' . AppApi::tableApikeys . ' WHERE `key`=:key;');
+            $query->closeCursor();
+
+            $query->execute([
+               ':key' => $apikeyString
+            ]);
+            $queueRaw = $query->fetch(\PDO::FETCH_ASSOC);
+            $this->apikey = new Apikey($queueRaw);
+
+            // Get application from apikey:
+            $query = $db->prepare('SELECT * FROM ' . AppApi::tableApplications . ' WHERE `id`=:id;');
+            $query->closeCursor();
+
+            $query->execute([
+               ':id' => $this->apikey->getApplicationID()
+            ]);
+            $queueRaw = $query->fetch(\PDO::FETCH_ASSOC);
+            $this->application = new Application($queueRaw);
+         } catch (\Throwable $e) {
+         }
+      } else {
+         try {
+            // Get default application that handles requests without an apikey:
+            $db = $this->wire('database');
+            $query = $db->prepare('SELECT * FROM ' . AppApi::tableApplications . ' WHERE `default_application`=true;');
+            $query->closeCursor();
+            $query->execute();
+            $queueRaw = $query->fetch(\PDO::FETCH_ASSOC);
+            if (!$queueRaw || !is_array($queueRaw)) {
+               throw new \Exception('No default application set.');
+            }
+            $this->application = new Application($queueRaw);
+         } catch (\Throwable $e) {
+         }
+      }
+   }
+
+   public function getApplication() {
+      return $this->application;
+   }
+
+   public function isApikeyValid() {
+      return ($this->apikey instanceof Apikey && $this->apikey->isAccessable() && $this->application instanceof Application) || ($this->apikey === false && $this->application instanceof Application);
+   }
+
+   public function getApikeyLog() {
+      if (!$this->isApikeyValid() || !($this->apikey instanceof Apikey)) {
+         return 'Apikey-ID: NONE';
+      }
+      return 'Apikey-ID: ' . $this->apikey->getID();
+   }
+
+   public function getApplicationLog() {
+      if (!$this->application) {
+         return 'Application-ID: NONE';
+      }
+      return 'Application-ID: ' . $this->application->getID();
+   }
+
+   protected function ___createSingleJWTToken($args = []) {
+      if ($this->wire('user')->isGuest()) {
+         throw new AuthException('user is not logged in', 401);
+      }
+
+      $apptoken = new Apptoken($this->application->getID());
+      $apptoken->setUser($this->wire('user'));
+      $apptoken->setExpirationTime(time() + $this->application->getExpiresIn());
+
+      $tokenArgs = [];
+      session_regenerate_id(true);
+      $sessionName = session_name();
+      $sid = $this->wire('input')->cookie($sessionName);
+      if (is_string($sid) && strlen($sid) > 0) {
+         $tokenArgs['sid'] = $sid;
+      }
+
+      $wiresChallengeWert = $this->wire('input')->cookie($sessionName . '_challenge');
+      if (is_string($wiresChallengeWert) && strlen($wiresChallengeWert) > 0) {
+         $tokenArgs['sid_challenge'] = $wiresChallengeWert;
+      }
+
+      $tokenArgs = array_merge($tokenArgs, $args);
+
+      $jwt = $apptoken->getJWT($this->application->getTokenSecret(), $tokenArgs);
+
+      $apptoken->save();
+
+      return $jwt;
+   }
+
+   public function ___doLogin($data) {
+      $access = $this->getLogintype($data);
+      $loggedIn = false;
+      $user = null;
+      $accessMethod = $access['method'];
+      $allowedLoginTypes = $this->application->getLogintype();
+      $params = (object)$access['params'];
+
+      if (
+         in_array($accessMethod, ['username-password', 'any-password']) &&
+         in_array('logintypeUsernamePassword', $allowedLoginTypes)
+      ) {
+         // Get login params
+         $username = isset($params->username) ? $params->username : null;
+         $password = isset($params->password) ? $params->password : null;
+
+         if (empty($username) || empty($password)) {
+            throw new AuthException('Login not successful', 401);
+         }
+
+         $user = $this->wire('users')->get('name=' . $username);
+
+         // prevent username sniffing by just throwing a general exception:
+         if ($user->id) {
+            $loggedIn = $this->wire('session')->login($user->name, $password);
+         }
+      }
+
+      if (
+         !$loggedIn &&
+         in_array($accessMethod, ['email-password', 'any-password']) &&
+         in_array('logintypeEmailPassword', $allowedLoginTypes)
+      ) {
+         // Get login params
+         $email = isset($params->email) ? $params->email : (isset($params->username) ? $params->username : null);
+         $password = isset($params->password) ? $params->password : null;
+
+         if (empty($email) || empty($password)) {
+            throw new AuthException('Login not successful', 401);
+         }
+
+         $user = $this->wire('users')->get('email=' . $email);
+
+
+         if ($user->id) {
+            $loggedIn = $this->wire('session')->login($user->name, $password);
+         }
+      }
+
+      // prevent username sniffing by just throwing a general exception:
+      if (!$user || !$user->id) {
+         throw new AuthException('Login not successful', 401);
+      }
+
+      if ($loggedIn) {
+         if ($this->application->getAuthtype() === Application::authtypeSession) {
+            return [
+               'success' => true,
+               'username' => $this->wire('user')->name,
+               'app' => $this->application->getAuthtype()
+            ];
+         }
+         if ($this->application->getAuthtype() === Application::authtypeSingleJWT) {
+            return [
+               'jwt' => $this->createSingleJWTToken(),
+               'username' => $this->wire('user')->name,
+               'app' => $this->application->getAuthtype()
+            ];
+         }
+         if ($this->application->getAuthtype() === Application::authtypeDoubleJWT) {
+            return [
+               'refresh_token' => $this->createRefreshToken(),
+               'username' => $this->wire('user')->name,
+               'app' => $this->application->getAuthtype()
+            ];
+         }
+         if ($this->application->getAuthtype() === Application::authtypeDoubleJWTsecure) {
+            return [
+               'refresh_token_expiration' => $this->createRefreshTokenSecure(),
+               'username' => $this->wire('user')->name,
+               'app' => $this->application->getAuthtype()
+            ];
+         }
+      }
+
+      throw new AuthException('Login not successfull', 401);
+   }
+
+   protected function ___createRefreshToken($args = []) {
+      if ($this->wire('user')->isGuest()) {
+         throw new AuthException('user is not logged in', 401);
+      }
+
+      $apptoken = new Apptoken($this->application->getID());
+      $apptoken->setUser($this->wire('user'));
+      $apptoken->setExpirationTime(time() + $this->application->getExpiresIn()); // Refreshtoken is valid for 30 days
+
+      $jwt = $apptoken->getJWT($this->application->getTokenSecret(), $args);
+
+      if (!$apptoken->save()) {
+         throw new InternalServererrorException('Token could not be saved', 500);
+      }
+
+      return $jwt;
+   }
+
+   protected function ___createRefreshTokenSecure($args = []) {
+      $jwt = $this->createRefreshToken();
+
+      $apptoken = new Apptoken($this->application->getID());
+      $expirationTime = time() + $this->application->getExpiresIn();
+
+      $this->input->cookie->set('refresh_token', 'Bearer ' . $jwt, [
+         'age' => $apptoken->getExpirationTime(),
+         'httponly' => true, // make visible to PHP but not JS
+         'secure' => isset($_SERVER['HTTPS']) ? true : null,
+         'domain' => true
+      ]);
+
+      return $expirationTime;
+   }
+
+
+   public function ___getAccessToken() {
+
+      $tokenString = null;
+      if ($this->application->getAuthtype() === Application::authtypeDoubleJWT) {
+         $tokenString = $this->getBearerToken();
+      } elseif ($this->application->getAuthtype() === Application::authtypeDoubleJWTsecure) {
+         $tokenString = $this->getBearerTokenSecure();
+      }
+      if ($tokenString === null or !is_string($tokenString) or empty($tokenString)) {
+         throw new AuthException('Your api-key does not support double-jwt authentication.', 400);
+      }
+
+      // throws exception if token is invalid:
+      $token = JWT::decode($tokenString, $this->application->getTokenSecret(), ['HS256']);
+      if (!is_object($token)) {
+         throw new AuthException('Invalid Token', 400);
+      }
+
+      $user = $this->wire('users')->get('id=' . $this->wire('sanitizer')->int($token->sub));
+      if (!($user instanceof User) || !$user->id) {
+         throw new AuthException('Invalid User', 400);
+      }
+
+      $refreshtokenFromDB = $this->application->getApptoken($token->jti);
+      if (!$refreshtokenFromDB instanceof Apptoken || !$refreshtokenFromDB->isValid()) {
+         throw new AuthException('Invalid Token', 400);
+      }
+
+      if ($user->isGuest() || $refreshtokenFromDB->getUser()->id !== $user->id) {
+         throw new AuthException('Invalid User', 400);
+      }
+
+      if (!$refreshtokenFromDB->isAccessable()) {
+         throw new RefreshtokenExpiredException();
+      }
+
+      if (!$refreshtokenFromDB->matchesWithJWT($token)) {
+         throw new RefreshtokenExpiredException();
+      }
+
+
+      $accesstoken = $this->createAccessTokenJWT($user, [
+         'rtkn' => $refreshtokenFromDB->getTokenID()
+      ]);
+
+
+      if ($this->application->getAuthtype() === Application::authtypeDoubleJWT) {
+         return [
+            'access_token' => $accesstoken,
+            'refresh_token' => $this->createRefreshToken(),
+         ];
+      }
+      if ($this->application->getAuthtype() === Application::authtypeDoubleJWTsecure) {
+         return [
+            'access_token' => $accesstoken,
+            'refresh_token_expiration' => $this->createRefreshTokenSecure(),
+         ];
+      }
+   }
+
+   protected function ___createAccessTokenJWT(User $user, $args = []) {
+      if ($user->isGuest()) {
+         throw new AuthException('user is not logged in', 401);
+      }
+
+      $apptoken = new Apptoken($this->application->getID());
+      $apptoken->setUser($user);
+      $apptoken->setExpirationTime(time() + $this->wire('config')->sessionExpireSeconds);
+
+      $tokenArgs = [];
+      session_regenerate_id(true);
+      $sessionName = session_name();
+      $wiresWert = $this->wire('input')->cookie($sessionName);
+      if (is_string($wiresWert) && strlen($wiresWert) > 0) {
+         $tokenArgs['sid'] = $wiresWert;
+      }
+
+      $wiresChallengeWert = $this->wire('input')->cookie($sessionName . '_challenge');
+      if (is_string($wiresChallengeWert) && strlen($wiresChallengeWert) > 0) {
+         $tokenArgs['sid_challenge'] = $wiresChallengeWert;
+      }
+
+      $tokenArgs = array_merge($tokenArgs, $args);
+
+      $jwt = $apptoken->getJWT($this->application->getAccesstokenSecret(), $tokenArgs);
+
+      return $jwt;
+   }
+
+   public function ___doLogout() {
+      // Remove Refresh-Token if Double-JWT:
+      try {
+         if (
+            $this->application->getAuthtype() === Application::authtypeDoubleJWT
+            or
+            $this->application->getAuthtype() === Application::authtypeDoubleJWTsecure
+         ) {
+
+            $tokenString = null;
+            $auth = $this->application->getAuthtype();
+            if ($auth === Application::authtypeDoubleJWT) {
+               $tokenString = $this->getBearerToken();
+            } elseif ($auth === Application::authtypeDoubleJWTsecure) {
+               $tokenString = $this->getBearerToken();
+            }
+
+            if ($tokenString === null || !is_string($tokenString) || empty($tokenString)) {
+               return false;
+            }
+
+            // throws exception if token is invalid:
+            try {
+               $secret = $this->application->getAccesstokenSecret();
+
+               $token = JWT::decode($tokenString, $secret, ['HS256']);
+            } catch (\Firebase\JWT\ExpiredException $e) {
+               throw new AccesstokenExpiredException();
+            } catch (\Firebase\JWT\BeforeValidException $e) {
+               throw new AccesstokenNotBeforeException();
+            } catch (\Throwable $e) {
+               throw new AccesstokenInvalidException();
+            }
+
+            if (!is_object($token)) {
+               throw new AccesstokenInvalidException();
+            }
+
+            $userid = $this->wire('sanitizer')->int($token->sub);
+            if (empty($userid) || $userid < 1) {
+               throw new AccesstokenInvalidException();
+            }
+
+            $user = $this->wire('users')->get('id=' . $userid);
+            if (!($user instanceof User) || !$user->id) {
+               throw new AccesstokenInvalidException();
+            }
+
+            // Get Refreshtoken that was used to generate this accesstoken:
+            $refreshtokenFromDB = $this->application->getApptoken($token->rtkn);
+            if (!$refreshtokenFromDB instanceof Apptoken || !$refreshtokenFromDB->isValid()) {
+               throw new AccesstokenInvalidException();
+            }
+
+            if ($user->isGuest() || $refreshtokenFromDB->getUser()->id !== $user->id) {
+               throw new AccesstokenInvalidException();
+            }
+
+            if (!$refreshtokenFromDB->matchesWithJWT($token)) {
+               throw new AccesstokenInvalidException();
+            }
+
+            if (!$refreshtokenFromDB->delete()) {
+               throw new InternalServererrorException('Token could not be removed', 500);
+            }
+         }
+      } catch (\Throwable $e) {
+         // todo log
+      }
+
+      $this->input->cookie->set('refresh_token', '', [
+         'age' => time() - 42000,
+         'httponly' => true, // make visible to PHP but not JS
+         'secure' => isset($_SERVER['HTTPS']) ? true : null,
+         'domain' => true
+      ]);
+
+      $this->wire('session')->logout($this->wire('user'));
+      return [
+         'success' => true
+      ];
+   }
+
+   /*------------------------------------*\
 	Login types
 	\*------------------------------------*/
-	public function getLogintype($data) {
-		$headers = AppApiHelper::getRequestHeaders();
+   public function getLogintype($data) {
+      $headers = AppApiHelper::getRequestHeaders();
 
-		if (
-			isset($data->username) &&
-			!empty($this->wire('sanitizer')->pageName($data->username)) &&
-			isset($data->password) &&
-			!empty('' . $data->password)
-		) {
-			// Authentication via POST-Param:
-			return [
-				'method' => 'username-password',
-				'params' => [
-					'username' => $data->username,
-					'password' => $data->password
-				],
-			];
-		}
+      if (
+         isset($data->username) &&
+         !empty($this->wire('sanitizer')->pageName($data->username)) &&
+         isset($data->password) &&
+         !empty('' . $data->password)
+      ) {
+         // Authentication via POST-Param:
+         return [
+            'method' => 'username-password',
+            'params' => [
+               'username' => $data->username,
+               'password' => $data->password
+            ],
+         ];
+      }
 
-		if (
-			isset($data->email) &&
-			!empty($this->wire('sanitizer')->email($data->email)) &&
-			isset($data->password) &&
-			!empty('' . $data->password)) {
-			// Authentication via POST-Param with email:
-			return [
-				'method' => 'email-password',
-				'params' => [
-					'email' => $data->email,
-					'password' => $data->password
-				],
-			];
-		}
+      if (
+         isset($data->email) &&
+         !empty($this->wire('sanitizer')->email($data->email)) &&
+         isset($data->password) &&
+         !empty('' . $data->password)
+      ) {
+         // Authentication via POST-Param with email:
+         return [
+            'method' => 'email-password',
+            'params' => [
+               'email' => $data->email,
+               'password' => $data->password
+            ],
+         ];
+      }
 
-		// Extract params from headers
-		$headersParams = null;
-		if (
-			!empty($headers['PHP_AUTH_USER']) &&
-			!empty($headers['PHP_AUTH_PW'])
-		) {
-			// Authentication via Authentication-Header:
-			$headersParams = (object)[
-				'username' => $headers['PHP_AUTH_USER'],
-				'password' => $headers['PHP_AUTH_PW']
-			];
-		}
+      // Extract params from headers
+      $headersParams = null;
+      if (
+         !empty($headers['PHP_AUTH_USER']) &&
+         !empty($headers['PHP_AUTH_PW'])
+      ) {
+         // Authentication via Authentication-Header:
+         $headersParams = (object)[
+            'username' => $headers['PHP_AUTH_USER'],
+            'password' => $headers['PHP_AUTH_PW']
+         ];
+      }
 
-		if (
-			!empty($headers['AUTHORIZATION']) &&
-			substr($headers['AUTHORIZATION'], 0, 6) === 'Basic '
-		) {
-			// Try manually extracting basic auth:
-			$authString = base64_decode(substr($headers['AUTHORIZATION'], 6)) ;
-			if ($authString) {
-				$authParts = explode(':', $authString, 2);
-				if (2 === count($authParts)) {
-					$headersParams = (object)[
-						'username' => $authParts[0],
-						'password' => $authParts[1]
-					];
-				}
-			}
-		}
+      if (
+         !empty($headers['AUTHORIZATION']) &&
+         substr($headers['AUTHORIZATION'], 0, 6) === 'Basic '
+      ) {
+         // Try manually extracting basic auth:
+         $authString = base64_decode(substr($headers['AUTHORIZATION'], 6));
+         if ($authString) {
+            $authParts = explode(':', $authString, 2);
+            if (2 === count($authParts)) {
+               $headersParams = (object)[
+                  'username' => $authParts[0],
+                  'password' => $authParts[1]
+               ];
+            }
+         }
+      }
 
-		if (
-			isset($headersParams->username) &&
-			!empty($this->wire('sanitizer')->pageName($headersParams->username)) &&
-			isset($headersParams->password) &&
-			!empty('' . $headersParams->password)
-		) {
-			return [
-				'method' => 'any-password',
-				'params' => [
-					'username' => $headersParams->username,
-					'password' => $headersParams->password
-				],
-			];
-		}
+      if (
+         isset($headersParams->password) &&
+         !empty('' . $headersParams->password) &&
+         isset($headersParams->username) &&
+         (!empty($email = $this->wire('sanitizer')->email($headersParams->username))
+            or
+            !empty($username = $this->wire('sanitizer')->pageName($headersParams->username))
+         )
+      ) {
+         return [
+            'method' => 'any-password',
+            'params' => [
+               'username' => !$email && !empty($username) ? $username : null,
+               'email' => !empty($email) ? $email : null,
+               'password' => $headersParams->password
+            ],
+         ];
+      }
 
-		if (
-			isset($headersParams->username) &&
-			!empty($this->wire('sanitizer')->email($headersParams->username)) &&
-			isset($headersParams->password) &&
-			!empty('' . $headersParams->password)
-		) {
-			return [
-				'method' => 'any-password',
-				'params' => [
-					'username' => $headersParams->username,
-					'password' => $headersParams->password
-				],
-			];
-		}
+      if (
+         isset($headersParams->username) &&
+         !empty($this->wire('sanitizer')->email($headersParams->username)) &&
+         isset($headersParams->password) &&
+         !empty('' . $headersParams->password)
+      ) {
+         return [
+            'method' => 'any-password',
+            'params' => [
+               'username' => $headersParams->username,
+               'password' => $headersParams->password
+            ],
+         ];
+      }
 
-		header('WWW-Authenticate: Basic realm="Access denied"');
-		throw new AuthException('Login not successful', 401);
-	}
+      header('WWW-Authenticate: Basic realm="Access denied"');
+      throw new AuthException('Login not successful', 401);
+   }
 
-	/**
-	 * Checks for Login-Tokens and authenticates the user in ProcessWire
-	 */
-	public function ___handleAuthentication() {
-		if ($this->application->getAuthtype() === Application::authtypeSingleJWT) {
-			return $this->handleToken(true);
-		} elseif ($this->application->getAuthtype() === Application::authtypeDoubleJWT) {
-			return $this->handleToken();
-		}
-	}
+   /**
+    * Checks for Login-Tokens and authenticates the user in ProcessWire
+    */
+   public function ___handleAuthentication() {
+      if ($this->application->getAuthtype() === Application::authtypeSingleJWT) {
+         return $this->handleToken(true);
+      } elseif ($this->application->getAuthtype() === Application::authtypeDoubleJWT) {
+         return $this->handleToken();
+      } elseif ($this->application->getAuthtype() === Application::authtypeDoubleJWTsecure) {
+         return $this->handleToken();
+      }
+   }
 
-	protected function ___handleToken($singleJwt = false) {
-		try {
-			$tokenString = $this->getBearerToken();
+   protected function ___handleToken($singleJwt = false) {
+      try {
 
-			if ($tokenString === null || !is_string($tokenString) || empty($tokenString)) {
-				$this->clearSession();
-				return false;
-			}
+         $tokenString = $this->getBearerToken();
+         // if ($this->application->getAuthtype() === Application::authtypeDoubleJWT) {
+         //   $tokenString = $this->getBearerToken();
+         // } elseif ($this->application->getAuthtype() === Application::authtypeDoubleJWTsecure) {
+         //   // Access token is retreived normally in a secure JWT mode
+         //   $tokenString = $this->getBearerToken();
+         // }
 
-			// throws exception if token is invalid:
-			try {
-				$secret = $this->application->getTokenSecret();
-				if (!$singleJwt) {
-					$secret = $this->application->getAccesstokenSecret();
-				}
-				$token = JWT::decode($tokenString, $secret, ['HS256']);
-			} catch (\Firebase\JWT\ExpiredException $e) {
-				throw new AccesstokenExpiredException();
-			} catch (\Firebase\JWT\BeforeValidException $e) {
-				throw new AccesstokenNotBeforeException();
-			} catch (\Throwable $e) {
-				throw new AccesstokenInvalidException();
-			}
+         if ($tokenString === null || !is_string($tokenString) || empty($tokenString)) {
+            $this->clearSession();
+            return false;
+         }
 
-			if (!is_object($token)) {
-				throw new AccesstokenInvalidException();
-			}
+         // throws exception if token is invalid:
+         try {
+            $secret = $this->application->getTokenSecret();
+            if (!$singleJwt) {
+               $secret = $this->application->getAccesstokenSecret();
+            }
+            $token = JWT::decode($tokenString, $secret, ['HS256']);
+         } catch (\Firebase\JWT\ExpiredException $e) {
+            throw new AccesstokenExpiredException();
+         } catch (\Firebase\JWT\BeforeValidException $e) {
+            throw new AccesstokenNotBeforeException();
+         } catch (\Throwable $e) {
+            throw new AccesstokenInvalidException();
+         }
 
-			$userid = $this->wire('sanitizer')->int($token->sub);
-			if (empty($userid) || $userid < 1) {
-				throw new AccesstokenInvalidException();
-			}
+         if (!is_object($token)) {
+            throw new AccesstokenInvalidException();
+         }
 
-			$user = $this->wire('users')->get('id=' . $userid);
-			if (!($user instanceof User) || !$user->id) {
-				throw new AccesstokenInvalidException();
-			}
+         $userid = $this->wire('sanitizer')->int($token->sub);
+         if (empty($userid) || $userid < 1) {
+            throw new AccesstokenInvalidException();
+         }
 
-			if (!$singleJwt) {
-				// Get Refreshtoken that was used to generate this accesstoken:
-				$refreshtokenFromDB = $this->application->getApptoken($token->rtkn);
-				if (!$refreshtokenFromDB instanceof Apptoken || !$refreshtokenFromDB->isValid()) {
-					throw new AccesstokenInvalidException();
-				}
+         $user = $this->wire('users')->get('id=' . $userid);
+         if (!($user instanceof User) || !$user->id) {
+            throw new AccesstokenInvalidException();
+         }
 
-				if ($user->isGuest() || $refreshtokenFromDB->getUser()->id !== $user->id) {
-					throw new AccesstokenInvalidException();
-				}
+         if (!$singleJwt) {
+            // Get Refreshtoken that was used to generate this accesstoken:
+            $refreshtokenFromDB = $this->application->getApptoken($token->rtkn);
+            if (!$refreshtokenFromDB instanceof Apptoken || !$refreshtokenFromDB->isValid()) {
+               throw new AccesstokenInvalidException();
+            }
 
-				if (!$refreshtokenFromDB->isAccessable()) {
-					throw new RefreshtokenExpiredException();
-				}
+            if ($user->isGuest() || $refreshtokenFromDB->getUser()->id !== $user->id) {
+               throw new AccesstokenInvalidException();
+            }
 
-				if (!$refreshtokenFromDB->matchesWithJWT($token)) {
-					throw new AccesstokenInvalidException();
-				}
+            if (!$refreshtokenFromDB->isAccessable()) {
+               throw new RefreshtokenExpiredException();
+            }
 
-				$refreshtokenFromDB->setLastUsed(time());
-				if (!$refreshtokenFromDB->save()) {
-					throw new InternalServererrorException('Token could not be saved', 500);
-				}
+            if (!$refreshtokenFromDB->matchesWithJWT($token)) {
+               throw new AccesstokenInvalidException();
+            }
 
-				$this->tokenId = $refreshtokenFromDB->getID();
-			}
+            $refreshtokenFromDB->setLastUsed(time());
+            if (!$refreshtokenFromDB->save()) {
+               throw new InternalServererrorException('Token could not be saved', 500);
+            }
 
-			$sessionname = session_name();
-			if (isset($token->sid)) {
-				$sid = $token->sid;
-				if (is_string($sid) && strlen($sid) > 0) {
-					$_COOKIE[$sessionname] = $sid;
-				}
-			}
+            $this->tokenId = $refreshtokenFromDB->getID();
+         }
 
-			if (isset($token->sid_challenge)) {
-				$sidChallenge = $token->sid_challenge;
-				if (is_string($sidChallenge) && strlen($sid) > 0) {
-					$_COOKIE[$sessionname . '_challenge'] = $sidChallenge;
-				}
-			}
-			$this->wire('users')->setCurrentUser($user);
-		} catch (\Throwable $e) {
-			$this->clearSession();
-			throw $e;
-		}
-	}
+         if ($this->application->getAuthtype() !== Application::authtypeDoubleJWTsecure) {
+            $sessionname = session_name();
+            if (isset($token->sid)) {
+               $sid = $token->sid;
+               if (is_string($sid) && strlen($sid) > 0) {
+                  $_COOKIE[$sessionname] = $sid;
+               }
+            }
 
-	public function ___clearSession() {
-		$this->wire('users')->setCurrentUser($this->wire('users')->get('guest'));
-	}
+            if (isset($token->sid_challenge)) {
+               $sidChallenge = $token->sid_challenge;
+               if (is_string($sidChallenge) && strlen($sid) > 0) {
+                  $_COOKIE[$sessionname . '_challenge'] = $sidChallenge;
+               }
+            }
+         }
 
-	/**
-	 * Only used for logging the currently used token
-	 *
-	 * @return void
-	 */
-	public function getTokenLog() {
-		if ($this->tokenId === false) {
-			return false;
-		}
-		return 'Token-ID: ' . $this->tokenId;
-	}
+         $this->wire('users')->setCurrentUser($user);
+      } catch (\Throwable $e) {
+         $this->clearSession();
+         throw $e;
+      }
+   }
 
-	protected function ___getBearerToken() {
-		$authorizationHeader = $this->getAuthorizationHeader();
+   public function ___clearSession() {
+      $this->wire('users')->setCurrentUser($this->wire('users')->get('guest'));
+   }
 
-		if ($authorizationHeader === null || !is_string($authorizationHeader) || strlen($authorizationHeader) < 7) {
-			if ($_GET && isset($_GET['authorization'])) {
-				$authorizationHeader = $_GET['authorization'];
-				if ($authorizationHeader === null || !is_string($authorizationHeader) || strlen($authorizationHeader) < 7) {
-					return null;
-				}
-			} else {
-				return null;
-			}
-		}
-		if (substr($authorizationHeader, 0, 7) !== 'Bearer ') {
-			return null;
-		}
-		return trim(substr($authorizationHeader, 7));
-	}
+   /**
+    * Only used for logging the currently used token
+    *
+    * @return void
+    */
+   public function getTokenLog() {
+      if ($this->tokenId === false) {
+         return false;
+      }
+      return 'Token-ID: ' . $this->tokenId;
+   }
 
-	protected function ___getAuthorizationHeader() {
-		$headers = AppApiHelper::getRequestHeaders();
-		if (!empty($headers['AUTHORIZATION'])) {
-			return $headers['AUTHORIZATION'];
-		} elseif (!empty($headers['HTTP_AUTHORIZATION'])) {
-			return $headers['HTTP_AUTHORIZATION'];
-		} elseif (!empty($headers['REDIRECT_HTTP_AUTHORIZATION'])) {
-			return $headers['REDIRECT_HTTP_AUTHORIZATION'];
-		}
+   protected function ___getBearerToken() {
+      $authorizationHeader = $this->getAuthorizationHeader();
 
-		return null;
-	}
+      if ($authorizationHeader === null || !is_string($authorizationHeader) || strlen($authorizationHeader) < 7) {
+         if ($_GET && isset($_GET['authorization'])) {
+            $authorizationHeader = $_GET['authorization'];
+            if ($authorizationHeader === null || !is_string($authorizationHeader) || strlen($authorizationHeader) < 7) {
+               return null;
+            }
+         } else {
+            return null;
+         }
+      }
+      if (substr($authorizationHeader, 0, 7) !== 'Bearer ') {
+         return null;
+      }
 
-	// Make Auth Singleton:
-	protected static $mainInstance;
+      // Need this special validation to run Postman automated tests
+      if (substr($authorizationHeader, 0, 9) == 'Bearer {{') {
+         return null;
+      }
+      return trim(substr($authorizationHeader, 7));
+   }
 
-	public static function getInstance() {
-		if (self::$mainInstance === null) {
-			self::$mainInstance = new Auth();
-		}
-		return self::$mainInstance;
-	}
+   protected function ___getAuthorizationHeader() {
+      $headers = AppApiHelper::getRequestHeaders();
+      if (!empty($headers['AUTHORIZATION'])) {
+         return $headers['AUTHORIZATION'];
+      } elseif (!empty($headers['HTTP_AUTHORIZATION'])) {
+         return $headers['HTTP_AUTHORIZATION'];
+      } elseif (!empty($headers['REDIRECT_HTTP_AUTHORIZATION'])) {
+         return $headers['REDIRECT_HTTP_AUTHORIZATION'];
+      }
 
-	// Static functions for Use in Routes:
-	public static function login($data) {
-		return self::getInstance()->doLogin($data);
-	}
+      return null;
+   }
 
-	public static function logout() {
-		return self::getInstance()->doLogout();
-	}
+   protected function ___getBearerTokenSecure() {
+      $authorizationCookie = $this->input->cookie->get('refresh_token');
 
-	public static function access() {
-		return self::getInstance()->getAccessToken();
-	}
+      if ($authorizationCookie === null || !is_string($authorizationCookie) || strlen($authorizationCookie) < 7) {
+         return null;
+      }
+      if (substr($authorizationCookie, 0, 7) !== 'Bearer ') {
+         return null;
+      }
 
-	public static function currentUser() {
-		return [
-			'id' => wire('user')->id,
-			'name' => wire('user')->name,
-			'loggedIn' => wire('user')->isLoggedIn()
-		];
-	}
+      // Need this special validation to run Postman automated tests
+      if (substr($authorizationCookie, 0, 9) == 'Bearer {{') {
+         return null;
+      }
+      return trim(substr($authorizationCookie, 7));
+   }
+
+   // Make Auth Singleton:
+   protected static $mainInstance;
+
+   public static function getInstance() {
+      if (self::$mainInstance === null) {
+         self::$mainInstance = new Auth();
+      }
+      return self::$mainInstance;
+   }
+
+   // Static functions for Use in Routes:
+   public static function login($data) {
+      return self::getInstance()->doLogin($data);
+   }
+
+   public static function logout() {
+      return self::getInstance()->doLogout();
+   }
+
+   public static function access() {
+      return self::getInstance()->getAccessToken();
+   }
+
+   public static function currentUser() {
+      return [
+         'id' => wire('user')->id,
+         'name' => wire('user')->name,
+         'loggedIn' => wire('user')->isLoggedIn(),
+      ];
+   }
 }
+
+
+
+
+
+
+
+
+
+
+?>

--- a/views/execute-application.php
+++ b/views/execute-application.php
@@ -1,70 +1,71 @@
 <?php
+
 namespace ProcessWire;
 
 if (!wire('user')->hasPermission(AppApi::manageApplicationsPermission)) {
-	echo '<h2>' . $this->_('Access denied') . '</h2>';
-	echo '<p>' . $this->_('You don\'t have the needed permissions to access this function. Please contact a Superuser.') . '</p>';
-	return;
+   echo '<h2>' . $this->_('Access denied') . '</h2>';
+   echo '<p>' . $this->_('You don\'t have the needed permissions to access this function. Please contact a Superuser.') . '</p>';
+   return;
 }
 
 if (isset($locked) && $locked === true) {
-	echo '<h2>' . $this->_('Access denied') . '</h2>';
-	if (!empty($message)) {
-		echo $message;
-	}
-	return;
+   echo '<h2>' . $this->_('Access denied') . '</h2>';
+   if (!empty($message)) {
+      echo $message;
+   }
+   return;
 }
 
 if (!isset($application) || !$application instanceof Application) {
-	$application = new Application();
-	$application->regenerateTokenSecret();
-	$application->regenerateAccesstokenSecret();
+   $application = new Application();
+   $application->regenerateTokenSecret();
+   $application->regenerateAccesstokenSecret();
 }
 
 if (!$application->isNew()) {
-	$apikeysTable = $modules->get('MarkupAdminDataTable');
-	$apikeysTable->setEncodeEntities(false);
+   $apikeysTable = $modules->get('MarkupAdminDataTable');
+   $apikeysTable->setEncodeEntities(false);
 
-	$apikeysTable->headerRow([
-		$this->_('Key'),
-		$this->_('Version'),
-		$this->_('Created'),
-		$this->_('Created by'),
-		$this->_('Accessable until'),
-		$this->_('Actions')
-	]);
+   $apikeysTable->headerRow([
+      $this->_('Key'),
+      $this->_('Version'),
+      $this->_('Created'),
+      $this->_('Created by'),
+      $this->_('Accessable until'),
+      $this->_('Actions')
+   ]);
 
-	$apikeys = $application->getApikeys();
+   $apikeys = $application->getApikeys();
 
-	if ($apikeys instanceof WireArray && $apikeys->count > 0) {
-		foreach ($apikeys as $apikey) {
-			$row = [
-				'<a href="' . $this->wire('page')->url . 'apikey/edit/' . $apikey->getID() . '">' . $apikey->getKey() . '</a>',
-				$apikey->getVersion(),
-				wire('datetime')->date('', $apikey->getCreated()),
-				$apikey->getCreatedUserLink(),
-				wire('datetime')->date('', $apikey->getAccessableUntil()),
-				'<a href="' . $this->wire('page')->url . 'apikey/delete/' . $apikey->getID() . '"><i class="fa fa-trash"></i></a>'
-			];
+   if ($apikeys instanceof WireArray && $apikeys->count > 0) {
+      foreach ($apikeys as $apikey) {
+         $row = [
+            '<a href="' . $this->wire('page')->url . 'apikey/edit/' . $apikey->getID() . '">' . $apikey->getKey() . '</a>',
+            $apikey->getVersion(),
+            wire('datetime')->date('', $apikey->getCreated()),
+            $apikey->getCreatedUserLink(),
+            wire('datetime')->date('', $apikey->getAccessableUntil()),
+            '<a href="' . $this->wire('page')->url . 'apikey/delete/' . $apikey->getID() . '"><i class="fa fa-trash"></i></a>'
+         ];
 
-			$apikeysTable->row($row);
-		}
+         $apikeysTable->row($row);
+      }
 
-		$apikeysTableOutput = $apikeysTable->render();
-	}
+      $apikeysTableOutput = $apikeysTable->render();
+   }
 
-	if (empty($apikeysTableOutput)) {
-		$apikeysTableOutput = '<p><i>' . $this->_('There are no apikeys set for this application.') . '</i></p>';
-	}
+   if (empty($apikeysTableOutput)) {
+      $apikeysTableOutput = '<p><i>' . $this->_('There are no apikeys set for this application.') . '</i></p>';
+   }
 
-	$button = $this->modules->get('InputfieldButton');
-	$button->value = $this->_('Add new Apikey');
-	$button->icon = 'plus';
-	$button->setSmall(true);
-	$button->attr('href', $this->wire('page')->url . 'apikey/new/' . $application->getID());
-	$apikeysTableOutput .= $button->render();
+   $button = $this->modules->get('InputfieldButton');
+   $button->value = $this->_('Add new Apikey');
+   $button->icon = 'plus';
+   $button->setSmall(true);
+   $button->attr('href', $this->wire('page')->url . 'apikey/new/' . $application->getID());
+   $apikeysTableOutput .= $button->render();
 } else {
-	$apikeysTableOutput = '<p><i>' . $this->_('You can add apikeys after saving the application the first time.') . '</i></p>';
+   $apikeysTableOutput = '<p><i>' . $this->_('You can add apikeys after saving the application the first time.') . '</i></p>';
 }
 
 // Build form:
@@ -100,9 +101,10 @@ $field->attr('id+name', 'form_authtype');
 $field->columnWidth = 20;
 $field->required = 1;
 $field->addOptions([
-	Application::authtypeSession => Application::getAuthtypeLabel(Application::authtypeSession),
-	Application::authtypeSingleJWT => Application::getAuthtypeLabel(Application::authtypeSingleJWT),
-	Application::authtypeDoubleJWT => Application::getAuthtypeLabel(Application::authtypeDoubleJWT)
+   Application::authtypeSession => Application::getAuthtypeLabel(Application::authtypeSession),
+   Application::authtypeSingleJWT => Application::getAuthtypeLabel(Application::authtypeSingleJWT),
+   Application::authtypeDoubleJWT => Application::getAuthtypeLabel(Application::authtypeDoubleJWT),
+   Application::authtypeDoubleJWTsecure => Application::getAuthtypeLabel(Application::authtypeDoubleJWTsecure)
 ]);
 $field->value = $application->getAuthtype();
 $field->collapsed = Inputfield::collapsedNever;
@@ -112,6 +114,7 @@ $descriptionString = '';
 $descriptionString .= '<p><strong>' . Application::getAuthtypeLabel(Application::authtypeSession) . ':</strong><br/>' . $this->_('A normal website-application can be used to access public data with only a valid apikey. Protected data will be authorized with classic php-sessions. If you are logged in, you can use protected apipages.') . '</p>';
 $descriptionString .= '<p><strong>' . Application::getAuthtypeLabel(Application::authtypeSingleJWT) . ':</strong><br/>' . $this->_('A protected website-application shows contents only if you have a valid JWT-token that authorizes you to use an endpoint. A JWT-token should be requested via PHP and has to be transferred to JS on pageload (e.g. as a special data-attribute). It can be limited to only those special endpoints that the api function uses. The JWT-token is linked to the php-session so it has a limited livetime. With protectedWebsite-endpoints we can prevent that api-access via token can be used for general apicalls from other services.') . '</p>';
 $descriptionString .= '<p><strong>' . Application::getAuthtypeLabel(Application::authtypeDoubleJWT) . ':</strong></br>' . $this->_('A classic app allows users to log in and authenticate via refresh- and access-tokens afterwards. Public contents are available with only a valid apikey.') . '</p>';
+$descriptionString .= '<p><strong>' . Application::getAuthtypeLabel(Application::authtypeDoubleJWTsecure) . ':</strong></br>' . $this->_('A secure double JWT saves the refresh_token in a secure httpOnly cookie that the client app cant access via JS, it returns the refresh_token_expiration date so that the client can handle the renewal, the cookie gets sent automatically with every request and is validated to provide an access_token, its recommended that the client app doesnt store the access_token anywhere so it can live safely in a memory state where an atacker cant access it, allows users to access via refresh- and access-tokens afterwards. Public contents are available with only a valid apikey..') . '</p>';
 
 $field = $this->modules->get('InputfieldMarkup');
 $field->attr('id+name', 'form_descriptions');
@@ -131,7 +134,7 @@ $field->columnWidth = 20;
 $field->required = 1;
 $loginTypeOptions = [];
 foreach (Application::logintypeOptions as $key => $loginTypeOption) {
-	$field->addOptions([$loginTypeOption => Application::getLogintypeLabel($loginTypeOption)]);
+   $field->addOptions([$loginTypeOption => Application::getLogintypeLabel($loginTypeOption)]);
 }
 $field->value = $application->getLogintype();
 $field->collapsed = Inputfield::collapsedNever;
@@ -221,64 +224,64 @@ $submitButton->header = false;
 $form->add($submitButton);
 
 if (!$application->isNew()) {
-	$button = $this->modules->get('InputfieldButton');
-	$button->href = $this->page->url . 'application/delete/' . $application->getID();
-	$button->value = 'delete';
-	$button->icon = 'trash-o';
-	$button->name = 'action-delete';
-	$button->secondary = true;
-	$form->add($button);
+   $button = $this->modules->get('InputfieldButton');
+   $button->href = $this->page->url . 'application/delete/' . $application->getID();
+   $button->value = 'delete';
+   $button->icon = 'trash-o';
+   $button->name = 'action-delete';
+   $button->secondary = true;
+   $form->add($button);
 }
 
 if (wire('input')->post('action-save')) {
-	// form submitted
-	$form->processInput(wire('input')->post);
-	$errors = $form->getErrors();
-	$messages = [];
+   // form submitted
+   $form->processInput(wire('input')->post);
+   $errors = $form->getErrors();
+   $messages = [];
 
-	if (count($errors)) {
-		// The submitted form-data has errors
-		foreach ($errors as $error) {
-			$this->session->error($error);
-		}
-	} else {
-		// The submitted form has no errors. We can save the application.
+   if (count($errors)) {
+      // The submitted form-data has errors
+      foreach ($errors as $error) {
+         $this->session->error($error);
+      }
+   } else {
+      // The submitted form has no errors. We can save the application.
 
-		try {
-			$doRedirect = $application->isNew();
+      try {
+         $doRedirect = $application->isNew();
 
-			$application->setModifiedUser(wire('user'));
-			$application->setTitle($form->get('form_title')->attr('value'));
-			$application->setDescription($form->get('form_description')->attr('value'));
-			$application->setDefaultApplication($form->get('form_default_application')->attr('value'));
-			$application->setTokenSecret($form->get('form_token_secret')->attr('value'));
-			$application->setAccesstokenSecret($form->get('form_accesstoken_secret')->attr('value'));
-			$application->setExpiresIn($form->get('form_expires_in')->attr('value'));
-			$application->setAuthtype($form->get('form_authtype')->attr('value'));
-			$application->setLogintype($form->get('form_logintype')->attr('value'));
+         $application->setModifiedUser(wire('user'));
+         $application->setTitle($form->get('form_title')->attr('value'));
+         $application->setDescription($form->get('form_description')->attr('value'));
+         $application->setDefaultApplication($form->get('form_default_application')->attr('value'));
+         $application->setTokenSecret($form->get('form_token_secret')->attr('value'));
+         $application->setAccesstokenSecret($form->get('form_accesstoken_secret')->attr('value'));
+         $application->setExpiresIn($form->get('form_expires_in')->attr('value'));
+         $application->setAuthtype($form->get('form_authtype')->attr('value'));
+         $application->setLogintype($form->get('form_logintype')->attr('value'));
 
-			if (!$application->save()) {
-				throw new \Exception('The application could not be saved.');
-			}
+         if (!$application->save()) {
+            throw new \Exception('The application could not be saved.');
+         }
 
-			$this->notices->add(new NoticeMessage($application->isNew() ? $this->_('The application was successfully created.') : $this->_('The changes to your application were saved.')));
+         $this->notices->add(new NoticeMessage($application->isNew() ? $this->_('The application was successfully created.') : $this->_('The changes to your application were saved.')));
 
-			if ($doRedirect) {
-				$this->session->redirect($this->wire('page')->url . 'application/edit/' . $application->getID());
-			}
-		} catch (\Exception $e) {
-			$this->session->error($e->getMessage());
-		}
-	}
+         if ($doRedirect) {
+            $this->session->redirect($this->wire('page')->url . 'application/edit/' . $application->getID());
+         }
+      } catch (\Exception $e) {
+         $this->session->error($e->getMessage());
+      }
+   }
 }
 
 if (!$application->isNew()) {
-	$field = $this->modules->get('InputfieldMarkup');
-	$field->label = $this->_('ID');
-	$field->columnWidth = '20%';
-	$field->value = $application->getID();
-	$field->collapsed = Inputfield::collapsedNever;
-	$form->prepend($field);
+   $field = $this->modules->get('InputfieldMarkup');
+   $field->label = $this->_('ID');
+   $field->columnWidth = '20%';
+   $field->value = $application->getID();
+   $field->collapsed = Inputfield::collapsedNever;
+   $form->prepend($field);
 }
 
 // Created- and Modified-Output is added after submission-handling, because only then the modified-date will have the correct time:
@@ -297,68 +300,68 @@ $field->collapsed = Inputfield::collapsedNever;
 $form->prepend($field);
 
 if (!$application->isNew() && $application->getAuthtype() === Application::authtypeDoubleJWT) {
-	$apptokensTable = $modules->get('MarkupAdminDataTable');
-	$apptokensTable->setEncodeEntities(false);
+   $apptokensTable = $modules->get('MarkupAdminDataTable');
+   $apptokensTable->setEncodeEntities(false);
 
-	$apptokensTable->headerRow([
-		$this->_('User'),
-		$this->_('id'),
-		$this->_('last used'),
-		$this->_('Actions')
-	]);
+   $apptokensTable->headerRow([
+      $this->_('User'),
+      $this->_('id'),
+      $this->_('last used'),
+      $this->_('Actions')
+   ]);
 
-	$apptokens = $application->getApptokens();
+   $apptokens = $application->getApptokens();
 
-	if ($apptokens instanceof WireArray && $apptokens->count > 0) {
-		foreach ($apptokens as $apptoken) {
-			$row = [
-				$apptoken->getUserLink(),
-				'<a href="' . $this->wire('page')->url . 'apptoken/edit/' . $apptoken->getID() . '">' . $apptoken->getTokenId() . '</a>',
-				$apptoken->getLastUsed() !== null ? wire('datetime')->date('', $apptoken->getLastUsed()) : '-',
-				'<a href="' . $this->wire('page')->url . 'apptoken/delete/' . $apptoken->getID() . '"><i class="fa fa-trash"></i></a>'
-			];
+   if ($apptokens instanceof WireArray && $apptokens->count > 0) {
+      foreach ($apptokens as $apptoken) {
+         $row = [
+            $apptoken->getUserLink(),
+            '<a href="' . $this->wire('page')->url . 'apptoken/edit/' . $apptoken->getID() . '">' . $apptoken->getTokenId() . '</a>',
+            $apptoken->getLastUsed() !== null ? wire('datetime')->date('', $apptoken->getLastUsed()) : '-',
+            '<a href="' . $this->wire('page')->url . 'apptoken/delete/' . $apptoken->getID() . '"><i class="fa fa-trash"></i></a>'
+         ];
 
-			$apptokensTable->row($row);
-		}
+         $apptokensTable->row($row);
+      }
 
-		$apptokensTableOutput = $apptokensTable->render();
-	}
+      $apptokensTableOutput = $apptokensTable->render();
+   }
 
-	if (empty($apptokensTableOutput)) {
-		$apptokensTableOutput = '<p><i>' . $this->_('There are no apptokens set for this application.') . '</i></p>';
-	}
+   if (empty($apptokensTableOutput)) {
+      $apptokensTableOutput = '<p><i>' . $this->_('There are no apptokens set for this application.') . '</i></p>';
+   }
 
-	$button = $this->modules->get('InputfieldButton');
-	$button->value = $this->_('Add new Apptoken');
-	$button->icon = 'plus';
-	$button->setSmall(true);
-	$button->attr('href', $this->wire('page')->url . 'apptoken/new/' . $application->getID());
-	$apptokensTableOutput .= $button->render();
+   $button = $this->modules->get('InputfieldButton');
+   $button->value = $this->_('Add new Apptoken');
+   $button->icon = 'plus';
+   $button->setSmall(true);
+   $button->attr('href', $this->wire('page')->url . 'apptoken/new/' . $application->getID());
+   $apptokensTableOutput .= $button->render();
 
-	$field = $this->modules->get('InputfieldMarkup');
-	$field->attr('id+name', 'form_apptokens');
-	$field->label = $this->_('Apptokens');
-	$field->value = $apptokensTableOutput;
-	$field->columnWidth = 100;
-	$form->insertBefore($field, $submitButton);
+   $field = $this->modules->get('InputfieldMarkup');
+   $field->attr('id+name', 'form_apptokens');
+   $field->label = $this->_('Apptokens');
+   $field->value = $apptokensTableOutput;
+   $field->columnWidth = 100;
+   $form->insertBefore($field, $submitButton);
 }
 
 // Output errors:
 if (isset($messages['errors']) && is_array($messages['errors'])) {
-	?>
-<div class="NoticeError" style="padding: 5px 10px;">
-	<strong><?= $this->_('The form has errors: '); ?></strong><br />
-	<?php
-		$firstFlag = true;
-	foreach ($messages['errors'] as $error) {
-		if ($firstFlag) {
-			echo $error;
-			$firstFlag = false;
-			continue;
-		}
-		echo '<br/>' . $error;
-	} ?>
-</div>
+?>
+   <div class="NoticeError" style="padding: 5px 10px;">
+      <strong><?= $this->_('The form has errors: '); ?></strong><br />
+      <?php
+      $firstFlag = true;
+      foreach ($messages['errors'] as $error) {
+         if ($firstFlag) {
+            echo $error;
+            $firstFlag = false;
+            continue;
+         }
+         echo '<br/>' . $error;
+      } ?>
+   </div>
 <?php
 }
 ?>
@@ -366,9 +369,7 @@ if (isset($messages['errors']) && is_array($messages['errors'])) {
 <?= $form->render(); ?>
 
 <p style='padding-top: 20px;'>
-	<a
-		href='<?= $this->wire('page')->url . 'applications/'; ?>'>
-		<i
-			class="fa fa-arrow-left"></i>&nbsp;<?= $this->_('Go Back'); ?>
-	</a>
+   <a href='<?= $this->wire('page')->url . 'applications/'; ?>'>
+      <i class="fa fa-arrow-left"></i>&nbsp;<?= $this->_('Go Back'); ?>
+   </a>
 </p>


### PR DESCRIPTION
A secure double JWT saves the refresh_token in a secure httpOnly cookie that the client app cant access via JS, it returns the refresh_token_expiration date so that the client can handle the renewal, the cookie gets sent automatically with every request and is validated to provide an access_token, its recommended that the client app doesnt store the access_token anywhere so it can live safely in a memory state where an atacker cant access it, allows users to access via refresh- and access-tokens afterwards. Public contents are available with only a valid apikey.